### PR TITLE
feat(cli): improve everyday ergonomics for single, multi, local, and global use

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,6 +1,12 @@
 name: reviewdog
 on: [pull_request]
 
+# reviewdog posts its findings as pull-request review comments, which needs
+# write access to pull requests; reading the checked-out code needs contents.
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   golangci-lint:
     name: golangci-lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and per-release binaries and notes are published from git tags by GoReleaser.
 
 ### Added
 
+- Author resolution for `check` (and `show`): with a single trained profile
+  `--author` is now optional, and a `default_author` setting (or `train
+  --default`) picks the author when several exist. Two or more profiles with no
+  default is a clear error that lists the candidates rather than guessing.
+- Profile management commands so `profiles/*.db` never has to be edited by hand:
+  `show` (how a profile was trained, with `--format json`), `rename` (keeps the
+  trained data, refuses to overwrite), and `remove` (clears the default if it
+  pointed there).
+- A per-user global store alongside the existing project-local model:
+  `omokage init --global`, the `OMOKAGE_HOME` environment variable, and the
+  `--global`, `--config PATH`, and `--profile-dir PATH` flags. A local project
+  always wins inside its tree; the global store is the fallback when none is
+  found.
+- `list --long` adds a table with each author's trained_at, file count, and
+  source directory, marking the default; plain `list` still prints bare names.
+- `check --score-only` prints just the integer similarity, for shell scripts.
 - `check --explain`: a prioritized, numeric drift report that leads with the
   high-level, editable features (register, script balance, sentence and
   paragraph shape) and shows each one's target value, the trained mean and

--- a/README.md
+++ b/README.md
@@ -50,10 +50,11 @@ $ omokage train --author me examples/posts
 Trained author "me" from 8 files.
 ```
 
-Check whether a draft still reads like that author.
+Check whether a draft still reads like that author. With a single trained
+profile you can drop `--author` entirely — omokage selects the only one.
 
 ```shell
-$ omokage check --author me examples/draft-keeps-voice.md
+$ omokage check examples/draft-keeps-voice.md
 Author: me
 Similarity: 73%
 
@@ -110,6 +111,70 @@ Paragraphs that drift most:
 ```
 
 ![explain demo](./doc/img/explain.gif)
+
+## Choosing the author
+
+`check` and `show` resolve the author in this order, so single-author use needs
+no flags and multi-author use stays unambiguous:
+
+1. `--author NAME`, if given;
+2. otherwise `default_author` from the config;
+3. otherwise the only trained profile;
+4. otherwise it is an error — zero profiles, or two or more with no default,
+   never silently picks one.
+
+Set a default without editing the config by hand:
+
+```shell
+$ omokage train --author me --default examples/posts
+```
+
+## Managing profiles
+
+You never have to touch `profiles/*.db` directly.
+
+```shell
+$ omokage list                 # bare names, one per line (pipe-friendly)
+me
+$ omokage list --long          # trained_at, file count, and source directory
+AUTHOR        TRAINED            FILES  SOURCE
+me (default)  2026-06-01 09:14   8      /home/me/writing/posts
+$ omokage show --author me      # how a profile was trained (--format json too)
+$ omokage rename --author me --to watashi
+$ omokage remove --author watashi
+```
+
+`rename` keeps the trained data and refuses to overwrite an existing author;
+`remove` clears `default_author` if it pointed at the removed profile.
+
+## Local and global stores
+
+By default omokage looks for an `omokage.toml` by walking up from the current
+directory — a project-local store, good for keeping separate writing contexts
+apart. For a single voice you can use anywhere, create a per-user store instead:
+
+```shell
+$ omokage init --global                       # under $OMOKAGE_HOME or ~/.config/omokage
+$ omokage train --global --author me ~/writing
+$ cd ~/anywhere && omokage check draft.md      # falls back to the global store
+```
+
+When both exist, a local project always wins inside its directory tree; the
+global store is the fallback used only when no local project is found. `--global`
+forces the global store from anywhere, and `--config PATH` / `--profile-dir PATH`
+point omokage at a specific store.
+
+## Scripting
+
+`--score-only` prints just the integer similarity, for shell pipelines:
+
+```shell
+$ score=$(omokage check --score-only draft.md)
+$ [ "$score" -ge 70 ] && echo "close enough"
+```
+
+Use `--format json` (with `check` or `show`) when a tool or LLM needs the full
+structured report instead of a single number.
 
 ## How it scores
 

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -8,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime/debug"
 	"strings"
+	"text/tabwriter"
 	"time"
 
 	"github.com/nao1215/omokage/internal/config"
@@ -54,6 +57,11 @@ type App struct {
 	stdout  io.Writer
 	stderr  io.Writer
 	workDir string
+	// home is the base directory of the global profile store. It is read from
+	// OMOKAGE_HOME, falling back to the per-user config directory. An empty home
+	// disables the global fallback, which keeps the tool from ever touching a
+	// user-wide store when one was never configured.
+	home string
 }
 
 func NewApp(stdout, stderr io.Writer, workDir string) *App {
@@ -61,7 +69,22 @@ func NewApp(stdout, stderr io.Writer, workDir string) *App {
 		stdout:  stdout,
 		stderr:  stderr,
 		workDir: workDir,
+		home:    resolveHome(),
 	}
+}
+
+// resolveHome locates the global store directory: OMOKAGE_HOME if set, otherwise
+// "<user config dir>/omokage" (e.g. ~/.config/omokage on Linux). It returns ""
+// only when neither is available, in which case --global and the global fallback
+// are simply unavailable rather than guessing a path.
+func resolveHome() string {
+	if h := strings.TrimSpace(os.Getenv("OMOKAGE_HOME")); h != "" {
+		return h
+	}
+	if dir, err := os.UserConfigDir(); err == nil && dir != "" {
+		return filepath.Join(dir, "omokage")
+	}
+	return ""
 }
 
 func (a *App) Run(args []string) int {
@@ -84,6 +107,12 @@ func (a *App) Run(args []string) int {
 		return a.runDiff(args[1:])
 	case "list":
 		return a.runList(args[1:])
+	case "show":
+		return a.runShow(args[1:])
+	case "remove":
+		return a.runRemove(args[1:])
+	case "rename":
+		return a.runRename(args[1:])
 	case "version", "-v", "--version":
 		writef(a.stdout, "omokage %s\n", resolveVersion())
 		return 0
@@ -94,54 +123,151 @@ func (a *App) Run(args []string) int {
 	}
 }
 
+// scopeFlags are the store-selection flags shared by every command that reads or
+// writes profiles. They are registered per command (rather than parsed globally)
+// so each subcommand's --help still lists them, while the definitions stay in one
+// place.
+type scopeFlags struct {
+	global     *bool
+	configPath *string
+	profileDir *string
+}
+
+func registerScopeFlags(flagSet *flag.FlagSet) scopeFlags {
+	return scopeFlags{
+		global:     flagSet.Bool("global", false, "use the global profile store (OMOKAGE_HOME) instead of searching for a local project"),
+		configPath: flagSet.String("config", "", "path to an omokage.toml to use, overriding project discovery"),
+		profileDir: flagSet.String("profile-dir", "", "directory of author profiles to use, overriding the config"),
+	}
+}
+
+func (a *App) resolveScope(sf scopeFlags) (project.Scope, error) {
+	return project.Resolve(project.ResolveOptions{
+		WorkDir:    a.workDir,
+		Home:       a.home,
+		Global:     *sf.global,
+		ConfigPath: strings.TrimSpace(*sf.configPath),
+		ProfileDir: strings.TrimSpace(*sf.profileDir),
+	})
+}
+
+// writeScopeError prints a resolve error, expanding the bare "project not found"
+// into an actionable hint that points at both the local and global entry points.
+func (a *App) writeScopeError(err error) {
+	if errors.Is(err, project.ErrProjectNotFound) {
+		writeLine(a.stderr, "omokage project not found; run 'omokage init' here, or 'omokage init --global' for a per-user store.")
+		return
+	}
+	writeLine(a.stderr, err)
+}
+
+// resolveAuthor decides which profile `check`/`show` act on when --author is
+// omitted. The rules are intentionally unambiguous:
+//
+//  1. an explicit --author always wins;
+//  2. else the scope's configured default_author;
+//  3. else, if exactly one profile exists, that one (the single-author case);
+//  4. else it is an error — zero profiles, or two-plus with no default, never
+//     silently picks one.
+func (a *App) resolveAuthor(scope project.Scope, explicit string) (string, error) {
+	if name := strings.TrimSpace(explicit); name != "" {
+		return name, nil
+	}
+	if name := strings.TrimSpace(scope.Config.Defaults.Author); name != "" {
+		return name, nil
+	}
+
+	authors, err := scope.ListProfiles()
+	if err != nil {
+		return "", err
+	}
+	switch len(authors) {
+	case 0:
+		return "", errors.New("no author profiles found; train one with 'omokage train --author NAME DIRECTORY'")
+	case 1:
+		return authors[0], nil
+	default:
+		// A bare --profile-dir scope has no config file, so "set a default in the
+		// config" is not an option there — only --author can disambiguate.
+		if scope.ConfigPath == "" {
+			return "", fmt.Errorf("multiple profiles found (%s); pass --author NAME (this --profile-dir store has no config file to record a default in)",
+				strings.Join(authors, ", "))
+		}
+		return "", fmt.Errorf("multiple profiles found (%s); pass --author NAME, or set a default with 'omokage train --default' (saved as default_author in %s)",
+			strings.Join(authors, ", "), scope.ConfigPath)
+	}
+}
+
 func (a *App) runInit(args []string) int {
 	flagSet := newFlagSet("init", a.stderr)
-	name := flagSet.String("name", filepath.Base(a.workDir), "project name")
+	global := flagSet.Bool("global", false, "create the per-user store under OMOKAGE_HOME instead of the current directory")
+	name := flagSet.String("name", "", "project name (defaults to the directory name)")
 	flagSet.Usage = func() {
-		writef(a.stderr, "Create an omokage project in the current directory (omokage.toml, profiles/, cache/).\n")
-		writef(a.stderr, "Usage: omokage init [--name NAME]\n")
+		writef(a.stderr, "Create an omokage store (omokage.toml, profiles/, cache/).\n")
+		writef(a.stderr, "Usage: omokage init [--global] [--name NAME]\n")
 		printFlagDefaults(a.stderr, flagSet)
 	}
-	if err := flagSet.Parse(args); err != nil {
-		return 1
+	if code, ok := parseArgs(flagSet, args); !ok {
+		return code
 	}
 	if flagSet.NArg() != 0 {
 		flagSet.Usage()
 		return 1
 	}
 
-	cfg, err := project.Init(a.workDir, *name)
+	dir := a.workDir
+	label := "project"
+	if *global {
+		if a.home == "" {
+			writeLine(a.stderr, "cannot determine the global store location; set OMOKAGE_HOME")
+			return 1
+		}
+		dir = a.home
+		label = "global store"
+		if err := os.MkdirAll(dir, 0o750); err != nil {
+			writeLine(a.stderr, err)
+			return 1
+		}
+	}
+
+	cfg, err := project.Init(dir, *name)
 	if err != nil {
 		writeLine(a.stderr, err)
 		return 1
 	}
 
-	writeLine(a.stdout, "Initialized omokage project.")
-	writef(a.stdout, "Config: %s\n", filepath.Join(a.workDir, project.ConfigFileName))
-	writef(a.stdout, "Profiles: %s\n", filepath.Join(a.workDir, cfg.Storage.ProfileDir))
-	writef(a.stdout, "Cache: %s\n", filepath.Join(a.workDir, cfg.Storage.CacheDir))
+	writef(a.stdout, "Initialized omokage %s.\n", label)
+	writef(a.stdout, "Config: %s\n", filepath.Join(dir, project.ConfigFileName))
+	writef(a.stdout, "Profiles: %s\n", filepath.Join(dir, cfg.Storage.ProfileDir))
+	writef(a.stdout, "Cache: %s\n", filepath.Join(dir, cfg.Storage.CacheDir))
 	return 0
 }
 
 func (a *App) runTrain(args []string) int {
 	flagSet := newFlagSet("train", a.stderr)
 	author := flagSet.String("author", "", "author profile name")
+	makeDefault := flagSet.Bool("default", false, "set this author as the store's default (used by check/show when --author is omitted)")
+	scopeF := registerScopeFlags(flagSet)
 	flagSet.Usage = func() {
 		writef(a.stderr, "Learn an author's style from every .md and .txt file in DIRECTORY.\n")
-		writef(a.stderr, "Usage: omokage train --author AUTHOR DIRECTORY\n")
+		writef(a.stderr, "Usage: omokage train --author AUTHOR [--default] DIRECTORY\n")
 		printFlagDefaults(a.stderr, flagSet)
 	}
-	if err := flagSet.Parse(args); err != nil {
-		return 1
+	if code, ok := parseArgs(flagSet, args); !ok {
+		return code
 	}
 	if strings.TrimSpace(*author) == "" || flagSet.NArg() != 1 {
 		flagSet.Usage()
 		return 1
 	}
 
-	root, cfg, err := project.Load(a.workDir)
+	scope, err := a.resolveScope(scopeF)
 	if err != nil {
-		writeLine(a.stderr, err)
+		a.writeScopeError(err)
+		return 1
+	}
+	if *makeDefault && scope.ConfigPath == "" {
+		writeLine(a.stderr, "cannot set --default: this store has no config file to record it in")
 		return 1
 	}
 
@@ -174,7 +300,7 @@ func (a *App) runTrain(args []string) int {
 		return 1
 	}
 
-	profilePath, err := project.ProfilePath(root, cfg, *author)
+	profilePath, err := scope.ProfilePath(*author)
 	if err != nil {
 		writeLine(a.stderr, err)
 		return 1
@@ -194,23 +320,39 @@ func (a *App) runTrain(args []string) int {
 
 	writef(a.stdout, "Trained author %q from %d files.\n", record.Author, record.FileCount)
 	writef(a.stdout, "Profile: %s\n", profilePath)
+
+	if *makeDefault {
+		// The profile is saved and valid at this point; setting it as the default is
+		// a separate write that can fail on its own (e.g. a read-only config). A
+		// freshly trained profile with no default is a consistent state, so on
+		// failure we report the partial result honestly instead of pretending the
+		// default was recorded.
+		scope.Config.Defaults.Author = *author
+		if err := scope.SaveConfig(); err != nil {
+			writef(a.stderr, "warning: the profile was trained, but setting it as the default failed: %v\n", err)
+			return 1
+		}
+		writef(a.stdout, "Default author set to %q.\n", *author)
+	}
 	return 0
 }
 
 func (a *App) runCheck(args []string) int {
 	flagSet := newFlagSet("check", a.stderr)
-	author := flagSet.String("author", "", "author profile name")
+	author := flagSet.String("author", "", "author profile name (optional: defaults to default_author or the only trained profile)")
 	explain := flagSet.Bool("explain", false, "print a prioritized, numeric drift report instead of the top-3 summary")
 	format := flagSet.String("format", formatText, "output format: text or json (json implies --explain)")
+	scoreOnly := flagSet.Bool("score-only", false, "print only the integer similarity (0-100), for scripts")
+	scopeF := registerScopeFlags(flagSet)
 	flagSet.Usage = func() {
 		writef(a.stderr, "Score how closely FILE matches AUTHOR's trained style, from 0 to 100.\n")
-		writef(a.stderr, "Usage: omokage check --author AUTHOR [--explain] [--format text|json] FILE\n")
+		writef(a.stderr, "Usage: omokage check [--author AUTHOR] [--explain] [--format text|json] [--score-only] FILE\n")
 		printFlagDefaults(a.stderr, flagSet)
 	}
-	if err := flagSet.Parse(args); err != nil {
-		return 1
+	if code, ok := parseArgs(flagSet, args); !ok {
+		return code
 	}
-	if strings.TrimSpace(*author) == "" || flagSet.NArg() != 1 {
+	if flagSet.NArg() != 1 {
 		flagSet.Usage()
 		return 1
 	}
@@ -219,14 +361,28 @@ func (a *App) runCheck(args []string) int {
 		flagSet.Usage()
 		return 1
 	}
+	// --score-only is the scalar, scripting output; --explain/--format json are the
+	// structured outputs. They answer different needs, so combining them is a
+	// mistake worth catching rather than silently picking one.
+	if *scoreOnly && (*explain || *format == formatJSON) {
+		writef(a.stderr, "--score-only cannot be combined with --explain or --format json\n")
+		flagSet.Usage()
+		return 1
+	}
 
-	root, cfg, err := project.Load(a.workDir)
+	scope, err := a.resolveScope(scopeF)
+	if err != nil {
+		a.writeScopeError(err)
+		return 1
+	}
+
+	resolvedAuthor, err := a.resolveAuthor(scope, *author)
 	if err != nil {
 		writeLine(a.stderr, err)
 		return 1
 	}
 
-	profilePath, err := project.ProfilePath(root, cfg, *author)
+	profilePath, err := scope.ProfilePath(resolvedAuthor)
 	if err != nil {
 		writeLine(a.stderr, err)
 		return 1
@@ -244,6 +400,17 @@ func (a *App) runCheck(args []string) int {
 		return 1
 	}
 
+	if *scoreOnly {
+		targetMetrics, err := feature.ExtractFile(targetPath)
+		if err != nil {
+			writeLine(a.stderr, err)
+			return 1
+		}
+		comparison := profile.Score(record.Distribution, targetMetrics, scope.Config.Features)
+		writef(a.stdout, "%d\n", comparison.Similarity)
+		return 0
+	}
+
 	// The plain path extracts whole-document metrics only. The explain/json path
 	// additionally splits the document into paragraphs so it can localize drift;
 	// that extra work runs only when the detailed output was requested.
@@ -256,7 +423,7 @@ func (a *App) runCheck(args []string) int {
 		}
 		renderComparison(a.stdout, renderOptions{
 			author:     record.Author,
-			comparison: profile.Score(record.Distribution, targetMetrics, cfg.Features),
+			comparison: profile.Score(record.Distribution, targetMetrics, scope.Config.Features),
 		})
 		// A one-line pointer to the detailed report, but only when a person is
 		// watching: it goes to stderr and only when stderr is a terminal. A pipe, a
@@ -274,7 +441,7 @@ func (a *App) runCheck(args []string) int {
 		writeLine(a.stderr, err)
 		return 1
 	}
-	explanation := profile.Explain(record.Distribution, targetMetrics, segments, cfg.Features)
+	explanation := profile.Explain(record.Distribution, targetMetrics, segments, scope.Config.Features)
 	if *format == formatJSON {
 		if err := renderExplanationJSON(a.stdout, record.Author, explanation); err != nil {
 			writeLine(a.stderr, err)
@@ -288,20 +455,27 @@ func (a *App) runCheck(args []string) int {
 
 func (a *App) runDiff(args []string) int {
 	flagSet := newFlagSet("diff", a.stderr)
+	scopeF := registerScopeFlags(flagSet)
 	flagSet.Usage = func() {
 		writef(a.stderr, "Compare two files directly and report their stylistic similarity, no profile needed.\n")
 		writef(a.stderr, "Usage: omokage diff FILE_A FILE_B\n")
+		printFlagDefaults(a.stderr, flagSet)
 	}
-	if err := flagSet.Parse(args); err != nil {
-		return 1
+	if code, ok := parseArgs(flagSet, args); !ok {
+		return code
 	}
 	if flagSet.NArg() != 2 {
 		flagSet.Usage()
 		return 1
 	}
 
-	cfg, err := a.defaultOrProjectConfig()
-	if err != nil {
+	// diff only needs the feature set, not a profile, so it works without any
+	// store: an active scope supplies the features, and its absence falls back to
+	// the defaults rather than erroring.
+	cfg := config.Default(filepath.Base(a.workDir))
+	if scope, err := a.resolveScope(scopeF); err == nil {
+		cfg = scope.Config
+	} else if !errors.Is(err, project.ErrProjectNotFound) {
 		writeLine(a.stderr, err)
 		return 1
 	}
@@ -339,44 +513,305 @@ func (a *App) runDiff(args []string) int {
 
 func (a *App) runList(args []string) int {
 	flagSet := newFlagSet("list", a.stderr)
+	long := flagSet.Bool("long", false, "show trained_at, file count, and source directory for each author")
+	scopeF := registerScopeFlags(flagSet)
 	flagSet.Usage = func() {
-		writef(a.stderr, "List the author profiles trained in this project.\n")
-		writef(a.stderr, "Usage: omokage list\n")
+		writef(a.stderr, "List the author profiles trained in the active store.\n")
+		writef(a.stderr, "Usage: omokage list [--long]\n")
+		printFlagDefaults(a.stderr, flagSet)
 	}
-	if err := flagSet.Parse(args); err != nil {
-		return 1
+	if code, ok := parseArgs(flagSet, args); !ok {
+		return code
 	}
 	if flagSet.NArg() != 0 {
 		flagSet.Usage()
 		return 1
 	}
 
-	root, cfg, err := project.Load(a.workDir)
+	scope, err := a.resolveScope(scopeF)
+	if err != nil {
+		a.writeScopeError(err)
+		return 1
+	}
+
+	authors, err := scope.ListProfiles()
 	if err != nil {
 		writeLine(a.stderr, err)
 		return 1
 	}
 
-	authors, err := project.ListProfiles(root, cfg)
+	// The short form stays a bare list of names: one per line, no header, so it
+	// pipes cleanly into other tools. --long is the human-facing, annotated view.
+	if !*long {
+		for _, author := range authors {
+			writeLine(a.stdout, author)
+		}
+		return 0
+	}
+
+	if len(authors) == 0 {
+		writeLine(a.stdout, "No author profiles trained yet.")
+		return 0
+	}
+
+	defaultAuthor := strings.TrimSpace(scope.Config.Defaults.Author)
+	tw := tabwriter.NewWriter(a.stdout, 0, 2, 2, ' ', 0)
+	writeLine(tw, "AUTHOR\tTRAINED\tFILES\tSOURCE")
+	for _, author := range authors {
+		profilePath, err := scope.ProfilePath(author)
+		if err != nil {
+			writeLine(a.stderr, err)
+			return 1
+		}
+		record, err := storage.LoadProfile(profilePath)
+		if err != nil {
+			writeLine(a.stderr, err)
+			return 1
+		}
+		name := author
+		if author == defaultAuthor {
+			// Mark the default so --long doubles as "which profile does a bare check
+			// use?" without a second command.
+			name += " (default)"
+		}
+		writef(tw, "%s\t%s\t%d\t%s\n",
+			name, record.TrainedAt.Format("2006-01-02 15:04 MST"), record.FileCount, record.SourceDir)
+	}
+	return flushTab(a.stderr, tw)
+}
+
+func (a *App) runShow(args []string) int {
+	flagSet := newFlagSet("show", a.stderr)
+	author := flagSet.String("author", "", "author profile to show (optional: defaults to default_author or the only trained profile)")
+	format := flagSet.String("format", formatText, "output format: text or json")
+	scopeF := registerScopeFlags(flagSet)
+	flagSet.Usage = func() {
+		writef(a.stderr, "Show how an author profile was trained: when, from how many files, and from where.\n")
+		writef(a.stderr, "Usage: omokage show [--author AUTHOR] [--format text|json]\n")
+		printFlagDefaults(a.stderr, flagSet)
+	}
+	if code, ok := parseArgs(flagSet, args); !ok {
+		return code
+	}
+	if flagSet.NArg() != 0 {
+		flagSet.Usage()
+		return 1
+	}
+	if *format != formatText && *format != formatJSON {
+		writef(a.stderr, "unknown --format %q: want text or json\n", *format)
+		flagSet.Usage()
+		return 1
+	}
+
+	scope, err := a.resolveScope(scopeF)
+	if err != nil {
+		a.writeScopeError(err)
+		return 1
+	}
+	resolvedAuthor, err := a.resolveAuthor(scope, *author)
 	if err != nil {
 		writeLine(a.stderr, err)
 		return 1
 	}
-	for _, author := range authors {
-		writeLine(a.stdout, author)
+	profilePath, err := scope.ProfilePath(resolvedAuthor)
+	if err != nil {
+		writeLine(a.stderr, err)
+		return 1
+	}
+	record, err := storage.LoadProfile(profilePath)
+	if err != nil {
+		writeLine(a.stderr, err)
+		return 1
+	}
+
+	if *format == formatJSON {
+		payload := profileSummaryJSON{
+			Author:         record.Author,
+			TrainedAt:      record.TrainedAt.Format(time.RFC3339),
+			FileCount:      record.FileCount,
+			SourceDir:      record.SourceDir,
+			DocumentCount:  record.Distribution.DocumentCount,
+			SentenceCount:  record.Distribution.SentenceCount,
+			CharacterCount: record.Distribution.CharacterCount,
+			Default:        record.Author == strings.TrimSpace(scope.Config.Defaults.Author),
+		}
+		encoder := json.NewEncoder(a.stdout)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(payload); err != nil {
+			writeLine(a.stderr, err)
+			return 1
+		}
+		return 0
+	}
+
+	writef(a.stdout, "Author: %s\n", record.Author)
+	if record.Author == strings.TrimSpace(scope.Config.Defaults.Author) {
+		writeLine(a.stdout, "Default: yes")
+	}
+	writef(a.stdout, "Trained: %s\n", record.TrainedAt.Format("2006-01-02 15:04:05 MST"))
+	writef(a.stdout, "Files: %d\n", record.FileCount)
+	writef(a.stdout, "Source: %s\n", record.SourceDir)
+	writef(a.stdout, "Documents: %d\n", record.Distribution.DocumentCount)
+	writef(a.stdout, "Sentences: %d\n", record.Distribution.SentenceCount)
+	writef(a.stdout, "Characters: %d\n", record.Distribution.CharacterCount)
+	return 0
+}
+
+func (a *App) runRemove(args []string) int {
+	flagSet := newFlagSet("remove", a.stderr)
+	author := flagSet.String("author", "", "author profile to remove")
+	scopeF := registerScopeFlags(flagSet)
+	flagSet.Usage = func() {
+		writef(a.stderr, "Remove an author profile from the active store.\n")
+		writef(a.stderr, "Usage: omokage remove --author AUTHOR\n")
+		printFlagDefaults(a.stderr, flagSet)
+	}
+	if code, ok := parseArgs(flagSet, args); !ok {
+		return code
+	}
+	if strings.TrimSpace(*author) == "" || flagSet.NArg() != 0 {
+		flagSet.Usage()
+		return 1
+	}
+
+	scope, err := a.resolveScope(scopeF)
+	if err != nil {
+		a.writeScopeError(err)
+		return 1
+	}
+	profilePath, err := scope.ProfilePath(*author)
+	if err != nil {
+		writeLine(a.stderr, err)
+		return 1
+	}
+	if _, err := os.Stat(profilePath); err != nil {
+		if os.IsNotExist(err) {
+			writef(a.stderr, "profile not found for author %q\n", *author)
+		} else {
+			writeLine(a.stderr, err)
+		}
+		return 1
+	}
+	// Clearing a dangling default and deleting the profile must not half-apply.
+	// Clear the default first (a read-only omokage.toml fails here, before anything
+	// is destroyed). If the profile delete then fails, restore the default so the
+	// store returns to its prior state rather than ending up with the profile still
+	// present but no default — which could make a later bare check ambiguous.
+	clearedDefault := false
+	if scope.ConfigPath != "" && strings.TrimSpace(scope.Config.Defaults.Author) == *author {
+		scope.Config.Defaults.Author = ""
+		if err := scope.SaveConfig(); err != nil {
+			writeLine(a.stderr, err)
+			return 1
+		}
+		clearedDefault = true
+	}
+	if err := os.Remove(profilePath); err != nil {
+		if clearedDefault {
+			scope.Config.Defaults.Author = *author
+			_ = scope.SaveConfig()
+		}
+		writeLine(a.stderr, err)
+		return 1
+	}
+
+	writef(a.stdout, "Removed author %q.\n", *author)
+	if clearedDefault {
+		writeLine(a.stdout, "Cleared the default author.")
 	}
 	return 0
 }
 
-func (a *App) defaultOrProjectConfig() (config.Config, error) {
-	cfg, found, err := project.LoadOptional(a.workDir)
+func (a *App) runRename(args []string) int {
+	flagSet := newFlagSet("rename", a.stderr)
+	author := flagSet.String("author", "", "current author name")
+	to := flagSet.String("to", "", "new author name")
+	scopeF := registerScopeFlags(flagSet)
+	flagSet.Usage = func() {
+		writef(a.stderr, "Rename an author profile, keeping its trained data.\n")
+		writef(a.stderr, "Usage: omokage rename --author OLD --to NEW\n")
+		printFlagDefaults(a.stderr, flagSet)
+	}
+	if code, ok := parseArgs(flagSet, args); !ok {
+		return code
+	}
+	if strings.TrimSpace(*author) == "" || strings.TrimSpace(*to) == "" || flagSet.NArg() != 0 {
+		flagSet.Usage()
+		return 1
+	}
+
+	scope, err := a.resolveScope(scopeF)
 	if err != nil {
-		return config.Config{}, err
+		a.writeScopeError(err)
+		return 1
 	}
-	if found {
-		return cfg, nil
+	oldPath, err := scope.ProfilePath(*author)
+	if err != nil {
+		writeLine(a.stderr, err)
+		return 1
 	}
-	return config.Default(filepath.Base(a.workDir)), nil
+	newPath, err := scope.ProfilePath(*to)
+	if err != nil {
+		writeLine(a.stderr, err)
+		return 1
+	}
+	if _, err := os.Stat(oldPath); err != nil {
+		if os.IsNotExist(err) {
+			writef(a.stderr, "profile not found for author %q\n", *author)
+		} else {
+			writeLine(a.stderr, err)
+		}
+		return 1
+	}
+	// Never overwrite an existing profile: a silent clobber would destroy trained
+	// data the user did not ask to lose.
+	if _, err := os.Stat(newPath); err == nil {
+		writef(a.stderr, "an author named %q already exists\n", *to)
+		return 1
+	} else if !os.IsNotExist(err) {
+		writeLine(a.stderr, err)
+		return 1
+	}
+
+	// Re-save under the new name (rewriting the stored author column) and then drop
+	// the old file, so the profile's data and its name never disagree.
+	record, err := storage.LoadProfile(oldPath)
+	if err != nil {
+		writeLine(a.stderr, err)
+		return 1
+	}
+	record.Author = *to
+	if err := storage.SaveProfile(newPath, record); err != nil {
+		writeLine(a.stderr, err)
+		return 1
+	}
+
+	// Order the writes so a failure never leaves a dangling default or a half-done
+	// rename: the new profile exists now, but the old one is still in place. Update
+	// the config next (the fragile write); if it fails, roll the new profile back
+	// out so the store returns to exactly its prior state. Only once the default is
+	// safely recorded do we drop the old profile and report success.
+	updatedDefault := false
+	if scope.ConfigPath != "" && strings.TrimSpace(scope.Config.Defaults.Author) == *author {
+		scope.Config.Defaults.Author = *to
+		if err := scope.SaveConfig(); err != nil {
+			_ = os.Remove(newPath)
+			scope.Config.Defaults.Author = *author
+			writeLine(a.stderr, err)
+			return 1
+		}
+		updatedDefault = true
+	}
+	if err := os.Remove(oldPath); err != nil {
+		writeLine(a.stderr, err)
+		return 1
+	}
+
+	writef(a.stdout, "Renamed author %q to %q.\n", *author, *to)
+	if updatedDefault {
+		writef(a.stdout, "Default author updated to %q.\n", *to)
+	}
+	return 0
 }
 
 func (a *App) printRootHelp() {
@@ -387,20 +822,57 @@ func (a *App) printRootHelp() {
 	writeLine(a.stdout, "  omokage <command> [arguments]")
 	writeLine(a.stdout)
 	writeLine(a.stdout, "Commands:")
-	writeLine(a.stdout, "  init     Create an omokage project here (omokage.toml, profiles/, cache/).")
+	writeLine(a.stdout, "  init     Create an omokage store here, or --global for a per-user one.")
 	writeLine(a.stdout, "  train    Learn an author's style from a directory of .md and .txt files.")
 	writeLine(a.stdout, "  check    Score how closely a file matches a trained author (--explain for details).")
 	writeLine(a.stdout, "  diff     Compare two files directly, without a trained profile.")
-	writeLine(a.stdout, "  list     List the author profiles trained in this project.")
+	writeLine(a.stdout, "  list     List the author profiles in the store (--long for details).")
+	writeLine(a.stdout, "  show     Show how an author profile was trained.")
+	writeLine(a.stdout, "  rename   Rename an author profile.")
+	writeLine(a.stdout, "  remove   Remove an author profile.")
 	writeLine(a.stdout, "  version  Print the omokage version.")
 	writeLine(a.stdout)
+	writeLine(a.stdout, `omokage uses a local project (omokage.toml found by walking up from the current`)
+	writeLine(a.stdout, `directory) when one exists, otherwise the global store at $OMOKAGE_HOME, or your`)
+	writeLine(a.stdout, `user config directory (e.g. ~/.config/omokage). 'omokage init --global' prints`)
+	writeLine(a.stdout, `the exact path it created.`)
+	writeLine(a.stdout)
+	writeLine(a.stdout, `check picks the author from --author, then default_author, then the only profile.`)
+	writeLine(a.stdout)
 	writeLine(a.stdout, `Run "omokage <command> --help" to see a command's arguments.`)
+}
+
+// profileSummaryJSON is the machine-readable form of `show`.
+type profileSummaryJSON struct {
+	Author         string `json:"author"`
+	TrainedAt      string `json:"trained_at"`
+	FileCount      int    `json:"file_count"`
+	SourceDir      string `json:"source_dir"`
+	DocumentCount  int    `json:"document_count"`
+	SentenceCount  int    `json:"sentence_count"`
+	CharacterCount int    `json:"character_count"`
+	Default        bool   `json:"default"`
 }
 
 func newFlagSet(name string, output io.Writer) *flag.FlagSet {
 	flagSet := flag.NewFlagSet(name, flag.ContinueOnError)
 	flagSet.SetOutput(output)
 	return flagSet
+}
+
+// parseArgs parses a subcommand's flags and reports whether the caller should
+// proceed. An explicit -h/--help is a successful request for the usage text (the
+// flag package has already printed it), so it maps to exit 0; any other parse
+// error maps to exit 1. Callers do `if code, ok := parseArgs(...); !ok { return
+// code }`.
+func parseArgs(flagSet *flag.FlagSet, args []string) (code int, ok bool) {
+	if err := flagSet.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0, false
+		}
+		return 1, false
+	}
+	return 0, true
 }
 
 // printFlagDefaults lists a command's flags using the double-dash spelling shown
@@ -471,6 +943,16 @@ func isTerminal(w io.Writer) bool {
 		return false
 	}
 	return info.Mode()&os.ModeCharDevice != 0
+}
+
+// flushTab flushes a tabwriter, reporting any error on stderr and turning it into
+// an exit code so a write failure is not swallowed.
+func flushTab(stderr io.Writer, tw *tabwriter.Writer) int {
+	if err := tw.Flush(); err != nil {
+		writeLine(stderr, err)
+		return 1
+	}
+	return 0
 }
 
 func writeLine(w io.Writer, args ...any) {

--- a/cmd/app_test.go
+++ b/cmd/app_test.go
@@ -253,10 +253,21 @@ func TestCheckRejectsUnknownFormat(t *testing.T) {
 
 func runApp(t *testing.T, workDir string, args ...string) (int, string, string) {
 	t.Helper()
+	// Point the global store at a path that does not exist, so tests never read or
+	// write a real per-user store and the global fallback stays inert unless a test
+	// opts in via runAppHome.
+	return runAppHome(t, workDir, filepath.Join(workDir, "__omokage_no_global__"), args...)
+}
+
+// runAppHome runs the app with an explicit global store directory, for the
+// global-mode and local/global-precedence tests.
+func runAppHome(t *testing.T, workDir, home string, args ...string) (int, string, string) {
+	t.Helper()
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	app := NewApp(&stdout, &stderr, workDir)
+	app.home = home
 	code := app.Run(args)
 	return code, stdout.String(), stderr.String()
 }

--- a/cmd/ergonomics_test.go
+++ b/cmd/ergonomics_test.go
@@ -1,0 +1,363 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// jaCorpus seeds a directory with a small polite-register Japanese corpus, the
+// same shape trainedProject uses, so the ergonomics tests can stand up extra
+// authors without repeating the fixtures.
+func jaCorpus(t *testing.T, dir string) {
+	t.Helper()
+	writeTestFile(t, filepath.Join(dir, "one.txt"), "今日は朝から雨が降っています。傘を持って出かけました。電車はとても混んでいました。")
+	writeTestFile(t, filepath.Join(dir, "two.txt"), "昨日は友人と食事に行きました。料理はどれも美味しかったです。また行きたいと思います。")
+	writeTestFile(t, filepath.Join(dir, "three.txt"), "週末は近くの公園を散歩しました。空気が澄んでいて気持ちが良かったです。")
+}
+
+func TestCheckSingleProfileNeedsNoAuthor(t *testing.T) {
+	t.Parallel()
+
+	// One trained profile: a bare `check` must auto-select it, removing the
+	// per-run --author friction in the common single-author case.
+	workDir := trainedProject(t)
+	writeTestFile(t, filepath.Join(workDir, "draft.txt"),
+		"今日はとても良い天気です。散歩に出かけました。気持ちが良かったです。")
+
+	code, stdout, stderr := runApp(t, workDir, "check", "draft.txt")
+	if code != 0 {
+		t.Fatalf("bare check failed: stderr=%q", stderr)
+	}
+	if !strings.Contains(stdout, "Author: me") || !strings.Contains(stdout, "Similarity:") {
+		t.Fatalf("expected the single profile to be auto-selected: %q", stdout)
+	}
+}
+
+func TestCheckDefaultAuthorWins(t *testing.T) {
+	t.Parallel()
+
+	workDir := trainedProject(t) // author "me"
+	jaCorpus(t, filepath.Join(workDir, "other"))
+	if code, _, stderr := runApp(t, workDir, "train", "--author", "other", "--default", "other"); code != 0 {
+		t.Fatalf("train --default failed: %s", stderr)
+	}
+	writeTestFile(t, filepath.Join(workDir, "draft.txt"), "本日は晴天なり。散歩に行きました。")
+
+	// Two profiles exist, but default_author=other was set, so a bare check uses it
+	// rather than erroring on ambiguity.
+	code, stdout, stderr := runApp(t, workDir, "check", "draft.txt")
+	if code != 0 {
+		t.Fatalf("default-author check failed: stderr=%q", stderr)
+	}
+	if !strings.Contains(stdout, "Author: other") {
+		t.Fatalf("expected the default author to be used: %q", stdout)
+	}
+
+	// An explicit --author still overrides the default.
+	code, stdout, _ = runApp(t, workDir, "check", "--author", "me", "draft.txt")
+	if code != 0 || !strings.Contains(stdout, "Author: me") {
+		t.Fatalf("explicit --author should override the default: %q", stdout)
+	}
+}
+
+func TestCheckAmbiguousProfilesError(t *testing.T) {
+	t.Parallel()
+
+	workDir := trainedProject(t) // author "me"
+	jaCorpus(t, filepath.Join(workDir, "other"))
+	if code, _, stderr := runApp(t, workDir, "train", "--author", "other", "other"); code != 0 {
+		t.Fatalf("second train failed: %s", stderr)
+	}
+	writeTestFile(t, filepath.Join(workDir, "draft.txt"), "本日は晴天なり。")
+
+	code, _, stderr := runApp(t, workDir, "check", "draft.txt")
+	if code == 0 {
+		t.Fatal("expected ambiguous profiles to fail without --author")
+	}
+	if !strings.Contains(stderr, "multiple profiles") {
+		t.Fatalf("expected an ambiguity error listing the authors, got %q", stderr)
+	}
+	if !strings.Contains(stderr, "me") || !strings.Contains(stderr, "other") {
+		t.Fatalf("the ambiguity error should name the candidates, got %q", stderr)
+	}
+}
+
+func TestCheckScoreOnly(t *testing.T) {
+	t.Parallel()
+
+	workDir := trainedProject(t)
+	writeTestFile(t, filepath.Join(workDir, "draft.txt"),
+		"今日はとても良い天気です。散歩に出かけました。気持ちが良かったです。")
+
+	code, stdout, stderr := runApp(t, workDir, "check", "--score-only", "draft.txt")
+	if code != 0 {
+		t.Fatalf("--score-only failed: stderr=%q", stderr)
+	}
+	trimmed := strings.TrimSpace(stdout)
+	if trimmed == "" {
+		t.Fatal("expected a numeric score on stdout")
+	}
+	// Output must be exactly the integer: no "Author:", no "Similarity:" label.
+	if strings.ContainsAny(trimmed, "AuthorSimilarity:%") {
+		t.Fatalf("--score-only must print only the integer, got %q", stdout)
+	}
+	for _, r := range trimmed {
+		if r < '0' || r > '9' {
+			t.Fatalf("--score-only output is not a bare integer: %q", stdout)
+		}
+	}
+}
+
+func TestCheckScoreOnlyRejectsStructuredFlags(t *testing.T) {
+	t.Parallel()
+
+	workDir := trainedProject(t)
+	writeTestFile(t, filepath.Join(workDir, "draft.txt"), "本日は晴天なり。")
+
+	if code, _, stderr := runApp(t, workDir, "check", "--score-only", "--explain", "draft.txt"); code == 0 ||
+		!strings.Contains(stderr, "--score-only cannot be combined") {
+		t.Fatalf("expected --score-only + --explain to be rejected, code=%d stderr=%q", code, stderr)
+	}
+	if code, _, stderr := runApp(t, workDir, "check", "--score-only", "--format", "json", "draft.txt"); code == 0 ||
+		!strings.Contains(stderr, "--score-only cannot be combined") {
+		t.Fatalf("expected --score-only + --format json to be rejected, code=%d stderr=%q", code, stderr)
+	}
+}
+
+func TestRemoveAuthor(t *testing.T) {
+	t.Parallel()
+
+	workDir := trainedProject(t)
+	if code, stdout, stderr := runApp(t, workDir, "remove", "--author", "me"); code != 0 ||
+		!strings.Contains(stdout, `Removed author "me"`) {
+		t.Fatalf("remove failed: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	// The profile is gone from the listing, and removing it again fails cleanly.
+	if _, stdout, _ := runApp(t, workDir, "list"); strings.Contains(stdout, "me") {
+		t.Fatalf("removed author still listed: %q", stdout)
+	}
+	if code, _, stderr := runApp(t, workDir, "remove", "--author", "me"); code == 0 ||
+		!strings.Contains(stderr, "profile not found") {
+		t.Fatalf("expected removing a missing author to fail, code=%d stderr=%q", code, stderr)
+	}
+}
+
+func TestRemoveClearsDefault(t *testing.T) {
+	t.Parallel()
+
+	workDir := trainedProject(t) // author "me"
+	if code, _, stderr := runApp(t, workDir, "train", "--author", "me", "--default", "posts"); code != 0 {
+		t.Fatalf("setting default failed: %s", stderr)
+	}
+	code, stdout, stderr := runApp(t, workDir, "remove", "--author", "me")
+	if code != 0 {
+		t.Fatalf("remove failed: stderr=%q", stderr)
+	}
+	if !strings.Contains(stdout, "Cleared the default author") {
+		t.Fatalf("expected the default to be cleared when its author is removed: %q", stdout)
+	}
+}
+
+func TestRenameAuthor(t *testing.T) {
+	t.Parallel()
+
+	workDir := trainedProject(t) // author "me"
+	code, stdout, stderr := runApp(t, workDir, "rename", "--author", "me", "--to", "watashi")
+	if code != 0 {
+		t.Fatalf("rename failed: stderr=%q", stderr)
+	}
+	if !strings.Contains(stdout, `Renamed author "me" to "watashi"`) {
+		t.Fatalf("unexpected rename output: %q", stdout)
+	}
+
+	// The old name is gone, the new name resolves, and the stored author column was
+	// rewritten (so `show` reports the new name).
+	_, listOut, _ := runApp(t, workDir, "list")
+	if strings.Contains(listOut, "me") && !strings.Contains(listOut, "watashi") {
+		t.Fatalf("rename did not move the profile: %q", listOut)
+	}
+	code, showOut, _ := runApp(t, workDir, "show", "--author", "watashi")
+	if code != 0 || !strings.Contains(showOut, "Author: watashi") {
+		t.Fatalf("renamed profile not readable as the new name: %q", showOut)
+	}
+}
+
+func TestRenameRefusesToClobber(t *testing.T) {
+	t.Parallel()
+
+	workDir := trainedProject(t) // author "me"
+	jaCorpus(t, filepath.Join(workDir, "other"))
+	if code, _, stderr := runApp(t, workDir, "train", "--author", "other", "other"); code != 0 {
+		t.Fatalf("train other failed: %s", stderr)
+	}
+	code, _, stderr := runApp(t, workDir, "rename", "--author", "me", "--to", "other")
+	if code == 0 || !strings.Contains(stderr, "already exists") {
+		t.Fatalf("expected rename onto an existing author to be refused, code=%d stderr=%q", code, stderr)
+	}
+}
+
+func TestRenameUpdatesDefault(t *testing.T) {
+	t.Parallel()
+
+	workDir := trainedProject(t)
+	if code, _, stderr := runApp(t, workDir, "train", "--author", "me", "--default", "posts"); code != 0 {
+		t.Fatalf("setting default failed: %s", stderr)
+	}
+	code, stdout, stderr := runApp(t, workDir, "rename", "--author", "me", "--to", "watashi")
+	if code != 0 {
+		t.Fatalf("rename failed: stderr=%q", stderr)
+	}
+	if !strings.Contains(stdout, `Default author updated to "watashi"`) {
+		t.Fatalf("expected the default to follow the rename: %q", stdout)
+	}
+	// A bare check now resolves through the updated default.
+	writeTestFile(t, filepath.Join(workDir, "draft.txt"), "本日は晴天なり。")
+	if code, out, _ := runApp(t, workDir, "check", "draft.txt"); code != 0 || !strings.Contains(out, "Author: watashi") {
+		t.Fatalf("default did not follow rename: code=%d out=%q", code, out)
+	}
+}
+
+func TestShowTextAndJSON(t *testing.T) {
+	t.Parallel()
+
+	workDir := trainedProject(t) // author "me", 3 files
+
+	code, stdout, stderr := runApp(t, workDir, "show", "--author", "me")
+	if code != 0 {
+		t.Fatalf("show failed: stderr=%q", stderr)
+	}
+	for _, want := range []string{"Author: me", "Trained:", "Files: 3", "Source:"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("show text missing %q:\n%s", want, stdout)
+		}
+	}
+
+	code, stdout, stderr = runApp(t, workDir, "show", "--author", "me", "--format", "json")
+	if code != 0 {
+		t.Fatalf("show --format json failed: stderr=%q", stderr)
+	}
+	var payload profileSummaryJSON
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("show json invalid: %v\n%s", err, stdout)
+	}
+	if payload.Author != "me" || payload.FileCount != 3 {
+		t.Fatalf("unexpected show json: %+v", payload)
+	}
+}
+
+func TestListLong(t *testing.T) {
+	t.Parallel()
+
+	workDir := trainedProject(t)
+
+	// Short form stays a bare list of names.
+	_, short, _ := runApp(t, workDir, "list")
+	if strings.TrimSpace(short) != "me" {
+		t.Fatalf("short list should be just names: %q", short)
+	}
+
+	code, long, stderr := runApp(t, workDir, "list", "--long")
+	if code != 0 {
+		t.Fatalf("list --long failed: stderr=%q", stderr)
+	}
+	for _, want := range []string{"AUTHOR", "TRAINED", "FILES", "SOURCE", "me"} {
+		if !strings.Contains(long, want) {
+			t.Fatalf("list --long missing %q:\n%s", want, long)
+		}
+	}
+}
+
+func TestGlobalInitAndCheck(t *testing.T) {
+	t.Parallel()
+
+	// No local project: work from a directory with no omokage.toml above it, and a
+	// dedicated global home.
+	workDir := t.TempDir()
+	home := filepath.Join(t.TempDir(), "omokage-home")
+	jaCorpus(t, filepath.Join(workDir, "posts"))
+	writeTestFile(t, filepath.Join(workDir, "draft.txt"), "本日は晴天なり。散歩に行きました。")
+
+	if code, stdout, stderr := runAppHome(t, workDir, home, "init", "--global"); code != 0 ||
+		!strings.Contains(stdout, "global store") {
+		t.Fatalf("init --global failed: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	if code, _, stderr := runAppHome(t, workDir, home, "train", "--global", "--author", "me", "posts"); code != 0 {
+		t.Fatalf("global train failed: %s", stderr)
+	}
+
+	// With a global store present and no local project, a bare check falls back to
+	// the global store and auto-selects the single profile.
+	code, stdout, stderr := runAppHome(t, workDir, home, "check", "draft.txt")
+	if code != 0 {
+		t.Fatalf("global fallback check failed: stderr=%q", stderr)
+	}
+	if !strings.Contains(stdout, "Author: me") {
+		t.Fatalf("expected the global profile to be used: %q", stdout)
+	}
+}
+
+func TestLocalWinsOverGlobal(t *testing.T) {
+	t.Parallel()
+
+	home := filepath.Join(t.TempDir(), "omokage-home")
+	workDir := t.TempDir()
+	jaCorpus(t, filepath.Join(workDir, "posts"))
+
+	// Global store trained with "global_author".
+	if code, _, stderr := runAppHome(t, workDir, home, "init", "--global"); code != 0 {
+		t.Fatalf("init --global failed: %s", stderr)
+	}
+	if code, _, stderr := runAppHome(t, workDir, home, "train", "--global", "--author", "global_author", "posts"); code != 0 {
+		t.Fatalf("global train failed: %s", stderr)
+	}
+
+	// Local project in workDir trained with "local_author".
+	if code, _, stderr := runAppHome(t, workDir, home, "init"); code != 0 {
+		t.Fatalf("local init failed: %s", stderr)
+	}
+	if code, _, stderr := runAppHome(t, workDir, home, "train", "--author", "local_author", "posts"); code != 0 {
+		t.Fatalf("local train failed: %s", stderr)
+	}
+
+	// Inside the local project, list must show only the local author: local wins.
+	code, stdout, stderr := runAppHome(t, workDir, home, "list")
+	if code != 0 {
+		t.Fatalf("list failed: stderr=%q", stderr)
+	}
+	if !strings.Contains(stdout, "local_author") || strings.Contains(stdout, "global_author") {
+		t.Fatalf("local project should win over global: %q", stdout)
+	}
+
+	// Forcing --global reaches the global store from the same directory.
+	code, stdout, _ = runAppHome(t, workDir, home, "list", "--global")
+	if code != 0 || !strings.Contains(stdout, "global_author") {
+		t.Fatalf("--global should reach the global store: %q", stdout)
+	}
+}
+
+func TestProfileDirOverride(t *testing.T) {
+	t.Parallel()
+
+	// --profile-dir points at an arbitrary directory with no config or project.
+	workDir := t.TempDir()
+	profileDir := filepath.Join(t.TempDir(), "myprofiles")
+	if err := os.MkdirAll(profileDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	jaCorpus(t, filepath.Join(workDir, "posts"))
+	writeTestFile(t, filepath.Join(workDir, "draft.txt"), "本日は晴天なり。散歩に行きました。")
+
+	if code, _, stderr := runApp(t, workDir, "train", "--profile-dir", profileDir, "--author", "me", "posts"); code != 0 {
+		t.Fatalf("train --profile-dir failed: %s", stderr)
+	}
+	if _, err := os.Stat(filepath.Join(profileDir, "me.db")); err != nil {
+		t.Fatalf("profile not written to --profile-dir: %v", err)
+	}
+	code, stdout, stderr := runApp(t, workDir, "check", "--profile-dir", profileDir, "draft.txt")
+	if code != 0 || !strings.Contains(stdout, "Author: me") {
+		t.Fatalf("check --profile-dir failed: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+}

--- a/cmd/robustness_test.go
+++ b/cmd/robustness_test.go
@@ -1,0 +1,200 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/omokage/internal/config"
+)
+
+func TestSubcommandHelpExitsZero(t *testing.T) {
+	t.Parallel()
+
+	// An explicit --help is a successful request for usage on every subcommand.
+	for _, name := range []string{"init", "train", "check", "diff", "list", "show", "remove", "rename"} {
+		if code, _, _ := runApp(t, t.TempDir(), name, "--help"); code != 0 {
+			t.Fatalf("%q --help should exit 0, got %d", name, code)
+		}
+	}
+	// A genuine parse error (unknown flag) still exits non-zero, so automation can
+	// tell "show me the help" apart from "you used me wrong".
+	if code, _, _ := runApp(t, t.TempDir(), "check", "--bogus"); code == 0 {
+		t.Fatal("an unknown flag should exit non-zero")
+	}
+}
+
+// readonlyConfig sets a project up with author "me" as the default, then makes
+// omokage.toml read-only so any later config write fails, and returns the config
+// path. It backs the atomicity tests for the default-author mutations.
+func readonlyConfig(t *testing.T, workDir string) string {
+	t.Helper()
+	if code, _, stderr := runApp(t, workDir, "train", "--author", "me", "--default", "posts"); code != 0 {
+		t.Fatalf("seeding the default failed: %s", stderr)
+	}
+	configPath := filepath.Join(workDir, "omokage.toml")
+	if err := os.Chmod(configPath, 0o400); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(configPath, 0o600) })
+	return configPath
+}
+
+func defaultAuthor(t *testing.T, configPath string) string {
+	t.Helper()
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("reload config: %v", err)
+	}
+	return cfg.Defaults.Author
+}
+
+func TestTrainDefaultReportsPartialOnConfigFailure(t *testing.T) {
+	t.Parallel()
+
+	workDir := trainedProject(t)
+	configPath := filepath.Join(workDir, "omokage.toml")
+	if err := os.Chmod(configPath, 0o400); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(configPath, 0o600) })
+
+	// Re-train "me" with --default against a read-only config. The profile is the
+	// command's purpose and must still be written; only the default can't be set,
+	// and the output must say so rather than claim the default was recorded.
+	code, stdout, stderr := runApp(t, workDir, "train", "--author", "me", "--default", "posts")
+	if code != 1 {
+		t.Fatalf("expected exit 1 when the default cannot be saved, got %d", code)
+	}
+	if !strings.Contains(stdout, `Trained author "me"`) {
+		t.Fatalf("the profile was trained, so that should be reported: %q", stdout)
+	}
+	if strings.Contains(stdout, "Default author set") {
+		t.Fatalf("must not claim the default was set when it failed: %q", stdout)
+	}
+	if !strings.Contains(stderr, "warning") {
+		t.Fatalf("expected a warning about the failed default: %q", stderr)
+	}
+	if got := defaultAuthor(t, configPath); got != "" {
+		t.Fatalf("the default must not be recorded on failure, got %q", got)
+	}
+}
+
+func TestRemoveLeavesStoreIntactOnConfigFailure(t *testing.T) {
+	t.Parallel()
+
+	workDir := trainedProject(t)
+	configPath := readonlyConfig(t, workDir)
+
+	// Removing the default author needs a config write to clear it. That write is
+	// done first, so when it fails nothing is deleted: the profile survives and the
+	// default still points at it. No half-applied state, no dangling default.
+	code, _, stderr := runApp(t, workDir, "remove", "--author", "me")
+	if code != 1 {
+		t.Fatalf("expected exit 1 when the config cannot be updated, got %d", code)
+	}
+	if strings.TrimSpace(stderr) == "" {
+		t.Fatal("expected an error explaining the failure")
+	}
+	if _, err := os.Stat(filepath.Join(workDir, "profiles", "me.db")); err != nil {
+		t.Fatalf("the profile must not be deleted when clearing the default failed: %v", err)
+	}
+	if got := defaultAuthor(t, configPath); got != "me" {
+		t.Fatalf("the default should be unchanged, got %q", got)
+	}
+}
+
+func TestRemoveRollsBackDefaultOnDeleteFailure(t *testing.T) {
+	t.Parallel()
+
+	workDir := trainedProject(t)
+	if code, _, stderr := runApp(t, workDir, "train", "--author", "me", "--default", "posts"); code != 0 {
+		t.Fatalf("seeding the default failed: %s", stderr)
+	}
+	configPath := filepath.Join(workDir, "omokage.toml")
+
+	// Make the profiles directory non-writable so os.Remove fails while the config
+	// stays writable. The default is cleared first, the delete then fails, and the
+	// default must be restored — never left cleared with the profile still present.
+	profilesDir := filepath.Join(workDir, "profiles")
+	// A directory needs its execute bit to be traversable, so 0500/0700 (not the
+	// 0600 gosec prefers for files) are the right modes for a read-only then
+	// restored directory fixture.
+	if err := os.Chmod(profilesDir, 0o500); err != nil { //nolint:gosec // directory perms need the execute bit
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(profilesDir, 0o700) }) //nolint:gosec // directory perms need the execute bit
+
+	code, _, stderr := runApp(t, workDir, "remove", "--author", "me")
+	if code != 1 {
+		t.Fatalf("expected exit 1 when the profile cannot be deleted, got %d", code)
+	}
+	if strings.TrimSpace(stderr) == "" {
+		t.Fatal("expected an error explaining the failure")
+	}
+	if _, err := os.Stat(filepath.Join(profilesDir, "me.db")); err != nil {
+		t.Fatalf("the profile should still be present after a failed delete: %v", err)
+	}
+	if got := defaultAuthor(t, configPath); got != "me" {
+		t.Fatalf("the default must be rolled back, not left cleared, got %q", got)
+	}
+}
+
+func TestProfileDirAmbiguityMentionsAuthorOnly(t *testing.T) {
+	t.Parallel()
+
+	// A bare --profile-dir scope has no config file, so the ambiguity error must
+	// not suggest setting a default there — only --author can disambiguate.
+	workDir := t.TempDir()
+	profileDir := filepath.Join(t.TempDir(), "profiles")
+	if err := os.MkdirAll(profileDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	jaCorpus(t, filepath.Join(workDir, "posts"))
+	writeTestFile(t, filepath.Join(workDir, "draft.txt"), "本日は晴天なり。")
+	for _, name := range []string{"alpha", "beta"} {
+		if code, _, stderr := runApp(t, workDir, "train", "--profile-dir", profileDir, "--author", name, "posts"); code != 0 {
+			t.Fatalf("train %s failed: %s", name, stderr)
+		}
+	}
+
+	code, _, stderr := runApp(t, workDir, "check", "--profile-dir", profileDir, "draft.txt")
+	if code == 0 {
+		t.Fatal("expected an ambiguity error with no --author")
+	}
+	if !strings.Contains(stderr, "--author") || !strings.Contains(stderr, "no config file") {
+		t.Fatalf("error should steer to --author and note the missing config: %q", stderr)
+	}
+	if strings.Contains(stderr, "set a default") || strings.Contains(stderr, "default_author") {
+		t.Fatalf("must not suggest an impossible default in a --profile-dir scope: %q", stderr)
+	}
+}
+
+func TestRenameRollsBackOnConfigFailure(t *testing.T) {
+	t.Parallel()
+
+	workDir := trainedProject(t)
+	configPath := readonlyConfig(t, workDir)
+
+	// Renaming the default author updates the config. When that write fails, the
+	// just-created profile is rolled back so the store returns to exactly its prior
+	// state: the old profile remains, the new one does not, and the default is
+	// unchanged.
+	code, _, stderr := runApp(t, workDir, "rename", "--author", "me", "--to", "watashi")
+	if code != 1 {
+		t.Fatalf("expected exit 1 when the config cannot be updated, got %d", code)
+	}
+	if strings.TrimSpace(stderr) == "" {
+		t.Fatal("expected an error explaining the failure")
+	}
+	if _, err := os.Stat(filepath.Join(workDir, "profiles", "me.db")); err != nil {
+		t.Fatalf("the original profile must survive a failed rename: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(workDir, "profiles", "watashi.db")); !os.IsNotExist(err) {
+		t.Fatalf("the new profile must be rolled back on failure, stat err=%v", err)
+	}
+	if got := defaultAuthor(t, configPath); got != "me" {
+		t.Fatalf("the default should still point at the original, got %q", got)
+	}
+}

--- a/cmd/robustness_test.go
+++ b/cmd/robustness_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -107,6 +108,14 @@ func TestRemoveLeavesStoreIntactOnConfigFailure(t *testing.T) {
 
 func TestRemoveRollsBackDefaultOnDeleteFailure(t *testing.T) {
 	t.Parallel()
+
+	// This test induces an os.Remove failure by making the profiles directory
+	// non-writable. On Windows the read-only attribute on a directory does not
+	// prevent deleting files inside it, so the failure cannot be induced this way.
+	// The rollback logic itself is platform-agnostic and is exercised on Unix.
+	if runtime.GOOS == "windows" {
+		t.Skip("directory permissions do not block file deletion on Windows")
+	}
 
 	workDir := trainedProject(t)
 	if code, _, stderr := runApp(t, workDir, "train", "--author", "me", "--default", "posts"); code != 0 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,10 +13,19 @@ type Config struct {
 	Project  Project
 	Features Features
 	Storage  Storage
+	Defaults Defaults
 }
 
 type Project struct {
 	Name string
+}
+
+// Defaults holds optional, scope-wide preferences. Author is the author profile
+// used by `check`/`show` when --author is omitted; it is consulted before the
+// single-profile auto-select and lets a multi-profile scope pick a sensible
+// default without forcing --author on every run.
+type Defaults struct {
+	Author string
 }
 
 type Features struct {
@@ -109,6 +118,14 @@ func Parse(data []byte) (Config, error) {
 				}
 				cfg.Project.Name = parsed
 			}
+		case "defaults":
+			if key == "default_author" {
+				parsed, err := parseString(value)
+				if err != nil {
+					return Config{}, err
+				}
+				cfg.Defaults.Author = parsed
+			}
 		case "features":
 			parsed, err := strconv.ParseBool(value)
 			if err != nil {
@@ -173,6 +190,10 @@ func (c Config) String() string {
 	return fmt.Sprintf(`[project]
 name = %q
 
+[defaults]
+# author used by `+"`check`"+`/`+"`show`"+` when --author is omitted (optional).
+default_author = %q
+
 [features]
 sentence_length = %t
 sentence_length_variance = %t
@@ -195,6 +216,7 @@ profile_dir = %q
 cache_dir = %q
 `,
 		c.Project.Name,
+		c.Defaults.Author,
 		c.Features.SentenceLength,
 		c.Features.SentenceLengthVariance,
 		c.Features.PunctuationFrequency,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -42,3 +42,31 @@ func TestSaveLoadRoundTrip(t *testing.T) {
 		t.Fatalf("unexpected profile dir: %q", actual.Storage.ProfileDir)
 	}
 }
+
+func TestDefaultAuthorRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "omokage.toml")
+	cfg := Default("writing-lab")
+	cfg.Defaults.Author = "me"
+	if err := Save(path, cfg); err != nil {
+		t.Fatal(err)
+	}
+	actual, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if actual.Defaults.Author != "me" {
+		t.Fatalf("default author not preserved: got %q", actual.Defaults.Author)
+	}
+
+	// A config without a [defaults] section parses to an empty default author,
+	// preserving backward compatibility with files written before the field.
+	legacy, err := Parse([]byte("[project]\nname = \"x\"\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if legacy.Defaults.Author != "" {
+		t.Fatalf("legacy config should have no default author, got %q", legacy.Defaults.Author)
+	}
+}

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	"github.com/nao1215/omokage/internal/config"
@@ -98,25 +97,5 @@ func ProfilePath(root string, cfg config.Config, author string) (string, error) 
 }
 
 func ListProfiles(root string, cfg config.Config) ([]string, error) {
-	profileDir := filepath.Join(root, cfg.Storage.ProfileDir)
-	entries, err := os.ReadDir(profileDir)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil, nil
-		}
-		return nil, err
-	}
-
-	authors := make([]string, 0, len(entries))
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		name := entry.Name()
-		if strings.HasSuffix(strings.ToLower(name), ".db") {
-			authors = append(authors, strings.TrimSuffix(name, filepath.Ext(name)))
-		}
-	}
-	sort.Strings(authors)
-	return authors, nil
+	return listProfilesInDir(filepath.Join(root, cfg.Storage.ProfileDir))
 }

--- a/internal/project/scope.go
+++ b/internal/project/scope.go
@@ -1,0 +1,219 @@
+package project
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/nao1215/omokage/internal/config"
+)
+
+// Scope is the resolved place a command reads and writes profiles. It unifies
+// the three ways omokage can be pointed at a profile store — a local project
+// found by walking up from the working directory, a global store under
+// OMOKAGE_HOME, or an explicit --config/--profile-dir override — behind a single
+// value so the command layer never has to special-case them.
+//
+// ProfileDir and CacheDir are absolute so they are stable regardless of the
+// working directory. ConfigPath is the omokage.toml backing this scope, or "" for
+// a bare --profile-dir scope that has no config file to write defaults into.
+type Scope struct {
+	// Kind is "local", "global", or "explicit"; used only for human-facing hints.
+	Kind       string
+	Root       string
+	ConfigPath string
+	ProfileDir string
+	CacheDir   string
+	Config     config.Config
+}
+
+const (
+	// ScopeLocal is a project found by walking up from the working directory.
+	ScopeLocal = "local"
+	// ScopeGlobal is the per-user store under OMOKAGE_HOME.
+	ScopeGlobal = "global"
+	// ScopeExplicit is a store named directly with --config or --profile-dir.
+	ScopeExplicit = "explicit"
+)
+
+// ResolveOptions describes how to locate the active scope. The precedence is
+// fixed in Resolve; these are the inputs that drive it.
+type ResolveOptions struct {
+	// WorkDir is the directory the command was invoked from.
+	WorkDir string
+	// Home is the global store base directory (OMOKAGE_HOME or its default). An
+	// empty Home disables the global fallback entirely, which keeps tests and
+	// project-only setups from ever touching a user-wide store by accident.
+	Home string
+	// Global forces the global store, skipping the upward project search.
+	Global bool
+	// ConfigPath names an omokage.toml to use directly.
+	ConfigPath string
+	// ProfileDir names a profile directory to use directly.
+	ProfileDir string
+}
+
+// Resolve picks the active scope using a fixed precedence:
+//
+//  1. --config / --profile-dir (explicit) — the caller named the store.
+//  2. --global — the per-user store under Home.
+//  3. a local project found by walking up from WorkDir — inside a project, local
+//     always wins, so the existing project-local model is untouched.
+//  4. the global store, but only when a global config already exists — this is
+//     the "use omokage anywhere" convenience and never silently invents a store.
+//  5. otherwise ErrProjectNotFound, exactly as before.
+func Resolve(o ResolveOptions) (Scope, error) {
+	if o.ConfigPath != "" || o.ProfileDir != "" {
+		return resolveExplicit(o)
+	}
+	if o.Global {
+		return resolveGlobal(o.Home)
+	}
+
+	root, err := FindRoot(o.WorkDir)
+	if err == nil {
+		cfg, loadErr := config.Load(filepath.Join(root, ConfigFileName))
+		if loadErr != nil {
+			return Scope{}, loadErr
+		}
+		return scopeFromRoot(ScopeLocal, root, cfg), nil
+	}
+	if !errors.Is(err, ErrProjectNotFound) {
+		return Scope{}, err
+	}
+
+	if o.Home != "" {
+		if _, statErr := os.Stat(filepath.Join(o.Home, ConfigFileName)); statErr == nil {
+			return resolveGlobal(o.Home)
+		}
+	}
+	return Scope{}, ErrProjectNotFound
+}
+
+func resolveExplicit(o ResolveOptions) (Scope, error) {
+	scope := Scope{Kind: ScopeExplicit, Config: config.Default("omokage")}
+
+	if o.ConfigPath != "" {
+		cfg, err := config.Load(o.ConfigPath)
+		if err != nil {
+			return Scope{}, err
+		}
+		abs, err := filepath.Abs(o.ConfigPath)
+		if err != nil {
+			return Scope{}, err
+		}
+		base := filepath.Dir(abs)
+		scope.Config = cfg
+		scope.ConfigPath = abs
+		scope.Root = base
+		scope.ProfileDir = absDir(base, cfg.Storage.ProfileDir)
+		scope.CacheDir = absDir(base, cfg.Storage.CacheDir)
+	}
+
+	if o.ProfileDir != "" {
+		abs, err := filepath.Abs(o.ProfileDir)
+		if err != nil {
+			return Scope{}, err
+		}
+		// An explicit --profile-dir wins over whatever a --config pointed at, so the
+		// two flags compose: --config supplies the feature set and default author,
+		// --profile-dir relocates only the profiles.
+		scope.ProfileDir = abs
+	}
+
+	if scope.ProfileDir == "" {
+		return Scope{}, errors.New("--config or --profile-dir did not yield a profile directory")
+	}
+	return scope, nil
+}
+
+func resolveGlobal(home string) (Scope, error) {
+	if home == "" {
+		return Scope{}, errors.New("global store location is unknown; set OMOKAGE_HOME")
+	}
+	cfgPath := filepath.Join(home, ConfigFileName)
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return Scope{}, fmt.Errorf("no global omokage store at %s; run 'omokage init --global'", home)
+		}
+		return Scope{}, err
+	}
+	return scopeFromRoot(ScopeGlobal, home, cfg), nil
+}
+
+func scopeFromRoot(kind, root string, cfg config.Config) Scope {
+	return Scope{
+		Kind:       kind,
+		Root:       root,
+		ConfigPath: filepath.Join(root, ConfigFileName),
+		ProfileDir: absDir(root, cfg.Storage.ProfileDir),
+		CacheDir:   absDir(root, cfg.Storage.CacheDir),
+		Config:     cfg,
+	}
+}
+
+// absDir resolves a possibly-relative storage directory against base, so the
+// "./profiles" stored in a config becomes an absolute path under its project.
+func absDir(base, dir string) string {
+	if filepath.IsAbs(dir) {
+		return filepath.Clean(dir)
+	}
+	return filepath.Clean(filepath.Join(base, dir))
+}
+
+// ProfilePath returns the SQLite path for an author inside this scope. The author
+// is validated the same way ProfilePath(root, cfg, author) is, so a name with a
+// path separator is rejected before it can escape the profile directory.
+func (s Scope) ProfilePath(author string) (string, error) {
+	safe := strings.TrimSpace(author)
+	if safe == "" {
+		return "", errors.New("author must not be empty")
+	}
+	if safe != filepath.Base(safe) {
+		return "", errors.New("author must not contain path separators")
+	}
+	return filepath.Join(s.ProfileDir, safe+".db"), nil
+}
+
+// ListProfiles returns the author names trained in this scope, sorted.
+func (s Scope) ListProfiles() ([]string, error) {
+	return listProfilesInDir(s.ProfileDir)
+}
+
+func listProfilesInDir(profileDir string) ([]string, error) {
+	entries, err := os.ReadDir(profileDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	authors := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if strings.HasSuffix(strings.ToLower(name), ".db") {
+			authors = append(authors, strings.TrimSuffix(name, filepath.Ext(name)))
+		}
+	}
+	sort.Strings(authors)
+	return authors, nil
+}
+
+// SaveConfig persists the scope's config back to its omokage.toml. It is used by
+// the commands that mutate scope-wide state (train --default, remove, rename) so
+// the default author stays in sync without the user editing the file by hand. A
+// scope with no config file (a bare --profile-dir) has nowhere to write to.
+func (s Scope) SaveConfig() error {
+	if s.ConfigPath == "" {
+		return errors.New("this scope has no config file to update (use --config or a project/global store)")
+	}
+	return config.Save(s.ConfigPath, s.Config)
+}

--- a/internal/project/scope_test.go
+++ b/internal/project/scope_test.go
@@ -1,0 +1,123 @@
+package project
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolvePrefersLocalOverGlobal(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	if _, err := Init(home, "global"); err != nil {
+		t.Fatal(err)
+	}
+	local := t.TempDir()
+	if _, err := Init(local, "local"); err != nil {
+		t.Fatal(err)
+	}
+
+	scope, err := Resolve(ResolveOptions{WorkDir: local, Home: home})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if scope.Kind != ScopeLocal || scope.Root != local {
+		t.Fatalf("expected local scope, got kind=%q root=%q", scope.Kind, scope.Root)
+	}
+}
+
+func TestResolveFallsBackToGlobal(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	if _, err := Init(home, "global"); err != nil {
+		t.Fatal(err)
+	}
+	// A working directory with no project above it falls back to the global store.
+	work := t.TempDir()
+	scope, err := Resolve(ResolveOptions{WorkDir: work, Home: home})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if scope.Kind != ScopeGlobal || scope.Root != home {
+		t.Fatalf("expected global scope, got kind=%q root=%q", scope.Kind, scope.Root)
+	}
+}
+
+func TestResolveNoStoreIsNotFound(t *testing.T) {
+	t.Parallel()
+
+	// No local project, and a home that has no config: this must stay the original
+	// "project not found" error rather than inventing a store.
+	if _, err := Resolve(ResolveOptions{WorkDir: t.TempDir(), Home: t.TempDir()}); !errors.Is(err, ErrProjectNotFound) {
+		t.Fatalf("expected ErrProjectNotFound, got %v", err)
+	}
+	// An empty home also yields not-found (the fallback is disabled).
+	if _, err := Resolve(ResolveOptions{WorkDir: t.TempDir(), Home: ""}); !errors.Is(err, ErrProjectNotFound) {
+		t.Fatalf("expected ErrProjectNotFound with no home, got %v", err)
+	}
+}
+
+func TestResolveGlobalFlagForces(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	if _, err := Init(home, "global"); err != nil {
+		t.Fatal(err)
+	}
+	local := t.TempDir()
+	if _, err := Init(local, "local"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Even inside a local project, --global forces the global store.
+	scope, err := Resolve(ResolveOptions{WorkDir: local, Home: home, Global: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if scope.Kind != ScopeGlobal {
+		t.Fatalf("expected --global to force global, got %q", scope.Kind)
+	}
+}
+
+func TestResolveExplicitProfileDir(t *testing.T) {
+	t.Parallel()
+
+	dir := filepath.Join(t.TempDir(), "profiles")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	scope, err := Resolve(ResolveOptions{WorkDir: t.TempDir(), ProfileDir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if scope.Kind != ScopeExplicit || scope.ProfileDir != dir {
+		t.Fatalf("unexpected explicit scope: kind=%q dir=%q", scope.Kind, scope.ProfileDir)
+	}
+	// A bare --profile-dir has no config file to write defaults into.
+	if scope.ConfigPath != "" {
+		t.Fatalf("explicit profile-dir scope should have no config path, got %q", scope.ConfigPath)
+	}
+}
+
+func TestResolveExplicitConfig(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	if _, err := Init(root, "explicit"); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(root, ConfigFileName)
+	scope, err := Resolve(ResolveOptions{WorkDir: t.TempDir(), ConfigPath: cfgPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if scope.Kind != ScopeExplicit {
+		t.Fatalf("expected explicit scope, got %q", scope.Kind)
+	}
+	if scope.ProfileDir != filepath.Join(root, "profiles") {
+		t.Fatalf("explicit config should resolve its profile dir, got %q", scope.ProfileDir)
+	}
+}

--- a/spec/check_diff_spec.sh
+++ b/spec/check_diff_spec.sh
@@ -142,10 +142,13 @@ Describe 'omokage check, diff, and list'
       The stderr should be present
     End
 
-    It 'requires the author flag'
+    It 'errors when the author is ambiguous'
+      # With two trained profiles and no default_author, a bare check must not
+      # guess: it reports the candidates and asks for --author.
       When run omokage check ja/keep.md
       The status should be failure
-      The stderr should include 'Usage: omokage check'
+      The stderr should include 'multiple profiles'
+      The stderr should include 'ja_me'
     End
   End
 

--- a/spec/cli_spec.sh
+++ b/spec/cli_spec.sh
@@ -42,9 +42,11 @@ Describe 'omokage CLI surface'
   End
 
   Describe 'subcommand help describes the command'
+    # An explicit --help is a successful request for usage, so it exits 0 (a real
+    # parse error still exits non-zero, covered below).
     It 'describes check and lists its flags with double dashes'
       When run "$OMOKAGE_BIN" check --help
-      The status should be failure
+      The status should be success
       The stderr should include 'Score how closely'
       The stderr should include 'Usage: omokage check'
       The stderr should include '--author'
@@ -54,29 +56,35 @@ Describe 'omokage CLI surface'
 
     It 'surfaces the explain and json options in check help'
       When run "$OMOKAGE_BIN" check --help
-      The status should be failure
+      The status should be success
       The stderr should include 'prioritized'
       The stderr should include 'text or json'
     End
 
     It 'does not show single-dash flag spellings in check help'
       When run "$OMOKAGE_BIN" check --help
-      The status should be failure
+      The status should be success
       The stderr should not include '  -author'
     End
 
     It 'describes init with a double-dash flag'
       When run "$OMOKAGE_BIN" init --help
-      The status should be failure
+      The status should be success
       The stderr should include 'Usage: omokage init'
       The stderr should include '--name'
     End
 
     It 'describes train'
       When run "$OMOKAGE_BIN" train --help
-      The status should be failure
+      The status should be success
       The stderr should include 'Learn an author'
       The stderr should include '--author'
+    End
+
+    It 'exits non-zero on an unknown flag (not a help request)'
+      When run "$OMOKAGE_BIN" check --bogus
+      The status should be failure
+      The stderr should be present
     End
   End
 End

--- a/spec/ergonomics_spec.sh
+++ b/spec/ergonomics_spec.sh
@@ -1,0 +1,163 @@
+#!/bin/sh
+# shellcheck shell=sh
+#
+# Everyday-use ergonomics: single-profile and default_author resolution for
+# check, the profile-management commands (remove/rename/show), the list output
+# modes, the script-friendly --score-only, and local/global precedence.
+
+Describe 'omokage ergonomics'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  Describe 'check author resolution'
+    BeforeEach 'fresh_project'
+    AfterEach 'remove_project'
+
+    It 'auto-selects the only profile when --author is omitted'
+      omokage train --author me ja/posts >/dev/null
+      When run omokage check ja/keep.md
+      The status should be success
+      The output should include 'Author: me'
+      The output should include 'Similarity:'
+    End
+
+    It 'uses default_author when several profiles exist'
+      omokage train --author me ja/posts >/dev/null
+      omokage train --author other --default ja/posts >/dev/null
+      When run omokage check ja/keep.md
+      The status should be success
+      The output should include 'Author: other'
+    End
+
+    It 'lets an explicit --author override the default'
+      omokage train --author me ja/posts >/dev/null
+      omokage train --author other --default ja/posts >/dev/null
+      When run omokage check --author me ja/keep.md
+      The status should be success
+      The output should include 'Author: me'
+    End
+
+    It 'errors when no profile has been trained yet'
+      When run omokage check ja/keep.md
+      The status should be failure
+      The stderr should include 'no author profiles'
+    End
+  End
+
+  Describe 'check --score-only'
+    BeforeEach 'fresh_project'
+    AfterEach 'remove_project'
+
+    It 'prints only the integer score'
+      omokage train --author me ja/posts >/dev/null
+      When run omokage check --score-only ja/keep.md
+      The status should be success
+      The output should not include 'Author'
+      The output should not include 'Similarity'
+      The output should not include '%'
+    End
+
+    It 'refuses to combine with --explain'
+      omokage train --author me ja/posts >/dev/null
+      When run omokage check --score-only --explain ja/keep.md
+      The status should be failure
+      The stderr should include 'cannot be combined'
+    End
+  End
+
+  Describe 'profile management'
+    BeforeEach 'fresh_project'
+    AfterEach 'remove_project'
+
+    It 'shows how a profile was trained'
+      omokage train --author me ja/posts >/dev/null
+      When run omokage show --author me
+      The status should be success
+      The output should include 'Author: me'
+      The output should include 'Files:'
+      The output should include 'Source:'
+    End
+
+    It 'removes a profile without touching the filesystem directly'
+      omokage train --author me ja/posts >/dev/null
+      When run omokage remove --author me
+      The status should be success
+      The output should include 'Removed author "me"'
+      The path "$WORK/profiles/me.db" should not be exist
+    End
+
+    It 'fails to remove an author that does not exist'
+      When run omokage remove --author ghost
+      The status should be failure
+      The stderr should include 'profile not found'
+    End
+
+    It 'renames a profile and keeps its data'
+      omokage train --author me ja/posts >/dev/null
+      omokage rename --author me --to watashi >/dev/null
+      When run omokage show --author watashi
+      The status should be success
+      The output should include 'Author: watashi'
+    End
+
+    It 'refuses to rename onto an existing author'
+      omokage train --author me ja/posts >/dev/null
+      omokage train --author other ja/posts >/dev/null
+      When run omokage rename --author me --to other
+      The status should be failure
+      The stderr should include 'already exists'
+    End
+  End
+
+  Describe 'list output modes'
+    BeforeEach 'fresh_project'
+    AfterEach 'remove_project'
+
+    It 'lists bare names by default'
+      omokage train --author me ja/posts >/dev/null
+      When run omokage list
+      The status should be success
+      The output should equal 'me'
+    End
+
+    It 'shows details with --long'
+      omokage train --author me ja/posts >/dev/null
+      When run omokage list --long
+      The status should be success
+      The output should include 'AUTHOR'
+      The output should include 'TRAINED'
+      The output should include 'SOURCE'
+      The output should include 'me'
+    End
+  End
+
+  Describe 'global store'
+    setup_global() {
+      make_workdir
+      OMOKAGE_HOME="$WORK/home"
+      export OMOKAGE_HOME
+    }
+    BeforeEach 'setup_global'
+    AfterEach 'remove_project'
+
+    It 'initializes and uses a global store with no local project'
+      omokage init --global >/dev/null
+      omokage train --global --author me ja/posts >/dev/null
+      # No local omokage.toml in $WORK, so a bare check falls back to the global
+      # store and auto-selects the single profile.
+      When run omokage check ja/keep.md
+      The status should be success
+      The output should include 'Author: me'
+    End
+
+    It 'prefers a local project over the global store'
+      omokage init --global >/dev/null
+      omokage train --global --author global_author ja/posts >/dev/null
+      omokage init >/dev/null
+      omokage train --author local_author ja/posts >/dev/null
+      When run omokage list
+      The status should be success
+      The output should include 'local_author'
+      The output should not include 'global_author'
+    End
+  End
+End

--- a/spec/spec_helper.sh
+++ b/spec/spec_helper.sh
@@ -17,9 +17,12 @@ OMOKAGE_BIN="${OMOKAGE_BIN:-$PROJECT_ROOT/omokage}"
 export OMOKAGE_BIN
 
 # omokage runs the built binary inside the current project directory ($WORK) so
-# that omokage.toml, profiles/, and relative fixture paths resolve there.
+# that omokage.toml, profiles/, and relative fixture paths resolve there. Unless a
+# test sets OMOKAGE_HOME itself, it points at a path that does not exist, so the
+# global-store fallback stays inert and the tests never touch a real per-user
+# store.
 omokage() {
-  ( cd "$WORK" && "$OMOKAGE_BIN" "$@" )
+  ( cd "$WORK" && OMOKAGE_HOME="${OMOKAGE_HOME:-$WORK/.omokage-global-absent}" "$OMOKAGE_BIN" "$@" )
 }
 
 # similarity prints just the integer percentage from a check/diff invocation.


### PR DESCRIPTION
## Summary

Improve daily CLI usability while keeping the existing project-local model as the default. All changes are additive; behavior changes are limited and called out below.

### Author selection (removes the `--author` friction)
`check`/`show` resolve the author when `--author` is omitted: **explicit `--author` → `default_author` → the only trained profile**. Two or more profiles with no default is a clear error listing the candidates — never a guess. `train --default` records the default without hand-editing the config.

### Profile management (no more touching `profiles/*.db`)
- `show --author NAME` (with `--format json`)
- `rename --author OLD --to NEW` (keeps trained data, refuses to clobber)
- `remove --author NAME` (clears a dangling default)

The default-author mutations are ordered and rolled back so a failed config write or profile delete never half-applies.

### Local and global stores
`init --global`, `OMOKAGE_HOME`, and `--global` / `--config` / `--profile-dir` add a per-user store. A local project always wins inside its tree; the global store is the fallback when none is found.

### Output ergonomics
- `list --long`: trained_at / file count / source table, marks the default; plain `list` still prints bare names.
- `check --score-only`: prints just the integer score, for scripts.

### Behavior changes
- A bare `check` with 2+ profiles and no default now errors (was impossible before, since `--author` was required).
- `<subcommand> --help` now exits `0` (a real parse error still exits non-zero).

## Tests
Go unit tests and ShellSpec E2E covering author resolution, ambiguity/failure paths (incl. read-only config and non-writable profiles dir), profile management, local/global precedence, and output modes. `make test`, `shellspec --shell sh` (61 examples), and `golangci-lint` all pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global per-user profile store (OMOKAGE_HOME) and init --global / --global support
  * Profile commands: show (text + JSON), rename, remove (clears/updates defaults)
  * Automatic author selection when a single trained profile exists
  * Configurable default author in project config (default_author)
  * list --long shows trained_at, file counts, source dir, and default marking
  * check --score-only prints only the integer similarity

* **Changed**
  * omokage version reports release tag; local project config now precedes global store
<!-- end of auto-generated comment: release notes by coderabbit.ai -->