### PR TITLE
release: v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and per-release binaries and notes are published from git tags by GoReleaser.
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-06-02
+
 ### Added
 
 - Author resolution for `check` (and `show`): with a single trained profile


### PR DESCRIPTION
## Summary

Cut the first tagged release, **v0.1.0**, of omokage. Pushing the `v0.1.0` tag after this merges triggers the GoReleaser workflow to publish cross-platform archives, checksums, and Linux packages.

## Changes

- Move the accumulated `[Unreleased]` notes under a `[0.1.0] - 2026-06-02` heading in `CHANGELOG.md`, leaving a fresh `[Unreleased]` section for future work.

## What ships in 0.1.0

- Author resolution for `check`/`show` (optional `--author`, `default_author`).
- Profile management: `show`, `rename`, `remove`.
- Per-user global store (`init --global`, `OMOKAGE_HOME`, `--global`/`--config`/`--profile-dir`).
- `list --long`, `check --score-only`, `check --explain`, `check --format json`.
- Paragraph-level drift localization.
- Release tooling (GoReleaser + tag-triggered release workflow) and `SECURITY.md`.
- `omokage version` reports the release tag via ldflags / module version.

## Release steps

1. Merge this PR.
2. Tag `main` with `v0.1.0` and push — the release workflow does the rest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - v0.1.0

* **New Features**
  * Author resolution defaults and profile management commands
  * Per-user global model storage with related configuration options
  * Enhanced output capabilities: extended listing, scoring mode, drift explanation, and JSON formatting
  * Paragraph-level drift localization
  * Security guidelines documentation

* **Changed**
  * Version information now reports release tag details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->