### PR TITLE
fix(ci): grant contents:write to the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: write
+
 jobs:
   release:
     name: Release


### PR DESCRIPTION
## Problem

The v0.1.0 release run built every archive, checksum, and Linux package successfully, but failed at the final step:

```
scm releases: failed to publish artifacts: could not release:
POST https://api.github.com/repos/nao1215/omokage/releases: 403 Resource not accessible by integration
```

The `release.yml` workflow declared no `permissions`, so the default `GITHUB_TOKEN` lacked the `contents: write` scope GoReleaser needs to create the GitHub Release.

## Fix

Add a top-level `permissions: contents: write` block to `release.yml`.

## Follow-up

After this merges, the `v0.1.0` tag will be re-pointed at the fixed commit so the release workflow re-runs and publishes the GitHub Release.