### PR TITLE
feat(term): learn and report per-profile notation preferences without an LLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,69 @@ Paragraphs that drift most:
 
 ![explain demo](./doc/img/explain.gif)
 
+## Term preferences
+
+Alongside the style distribution, `train` learns which surface form you actually
+use for a recurring term — `DB` or `データベース`, `HTTP` or `http` — and stores
+it in the same per-author database. Like everything else in omokage this runs
+fully locally: no LLM, no network, no external dictionary, and the original
+training text is never stored — only surfaces and their counts. The extraction is
+deterministic, so the same corpus always yields the same result.
+
+Two separate ideas keep the merging conservative:
+
+- **`normalized_key`** folds away differences that never change meaning — letter
+  case, full-width/half-width ASCII, and surrounding punctuation — so `DB`, `db`,
+  and `ＤＢ` share one normalized key.
+- **`group_key`** identifies a same-concept group. Two *different* normalized keys
+  are merged into one group **only when the corpus itself spells out the bridge**,
+  e.g. `データベース（DB）`, `DB（データベース）`, `データベース（以下 DB）`, or
+  `データベース。以下、DB`. A bare `A（B）` is never enough: one side must be a
+  Japanese phrase and the other a short uppercase acronym. So `優先度` and
+  `プライオリティ` stay separate unless the text bridges them. Because the two keys
+  are stored separately you can always tell a normalization merge (one
+  `normalized_key`) from an alias-bridge merge (several `normalized_key`s under one
+  `group_key`).
+
+Within a group the **preferred surface** is chosen in a fixed, stable order:
+highest `doc_count` first, then highest `count`, then the lexicographically
+smallest surface as a deterministic tie-break.
+
+`show --format json` adds a `term_preferences` array (the text output stays a
+short provenance summary):
+
+```jsonc
+"term_preferences": [
+  {
+    "group_key": "term:db",
+    "preferred_surface": "DB",
+    "doc_count": 2,
+    "total_count": 7,
+    "variants": [
+      { "surface": "DB", "normalized_key": "db", "count": 5, "doc_count": 2 },
+      { "surface": "データベース", "normalized_key": "データベース", "count": 2, "doc_count": 1 }
+    ]
+  }
+]
+```
+
+`check --format json` adds a `term_warnings` array for any surface in the draft
+that differs from the group's preferred one. It is a **separate layer from the
+similarity score and never changes it**:
+
+```jsonc
+"term_warnings": [
+  { "group_key": "term:db", "preferred_surface": "DB", "used_surface": "ＤＢ", "count": 1 }
+]
+```
+
+(`occurrences` with line/column information is a reserved, optional field for a
+future version; only counts are reported today.) Term preferences appear only in
+the JSON output, so plain `check` stays fast and unchanged. Candidate extraction
+is intentionally lightweight — Japanese kanji/katakana runs and ASCII words and
+acronyms; half-width katakana and semantic synonyms without a corpus-declared
+bridge are out of scope for now.
+
 ## Choosing the author
 
 `check` and `show` resolve the author in this order, so single-author use needs

--- a/README.md
+++ b/README.md
@@ -149,66 +149,25 @@ Paragraphs that drift most:
 
 ## Term preferences
 
-Alongside the style distribution, `train` learns which surface form you actually
-use for a recurring term — `DB` or `データベース`, `HTTP` or `http` — and stores
-it in the same per-author database. Like everything else in omokage this runs
-fully locally: no LLM, no network, no external dictionary, and the original
-training text is never stored — only surfaces and their counts. The extraction is
-deterministic, so the same corpus always yields the same result.
+`train` also learns which surface form you use for a recurring term (`DB` vs
+`データベース`, `HTTP` vs `http`) and stores it in the same per-author database.
+This runs locally like the rest of omokage: no LLM, no network, no dictionary,
+and only surfaces and counts are stored, never the training text.
 
-Two separate ideas keep the merging conservative:
+A `normalized_key` folds case, full-width/half-width ASCII, and edge punctuation,
+so `DB`, `db`, and `ＤＢ` share one key. A `group_key` merges different normalized
+keys into one concept only when the corpus declares the bridge itself, such as
+`データベース（DB）` or `データベース。以下、DB`; one side must be a Japanese phrase
+and the other a short uppercase acronym. A bare `A（B）` is not enough, so `優先度`
+and `プライオリティ` stay separate unless bridged. The preferred surface of a group
+is the one with the highest `doc_count`, then `count`, then the smallest surface.
 
-- **`normalized_key`** folds away differences that never change meaning — letter
-  case, full-width/half-width ASCII, and surrounding punctuation — so `DB`, `db`,
-  and `ＤＢ` share one normalized key.
-- **`group_key`** identifies a same-concept group. Two *different* normalized keys
-  are merged into one group **only when the corpus itself spells out the bridge**,
-  e.g. `データベース（DB）`, `DB（データベース）`, `データベース（以下 DB）`, or
-  `データベース。以下、DB`. A bare `A（B）` is never enough: one side must be a
-  Japanese phrase and the other a short uppercase acronym. So `優先度` and
-  `プライオリティ` stay separate unless the text bridges them. Because the two keys
-  are stored separately you can always tell a normalization merge (one
-  `normalized_key`) from an alias-bridge merge (several `normalized_key`s under one
-  `group_key`).
-
-Within a group the **preferred surface** is chosen in a fixed, stable order:
-highest `doc_count` first, then highest `count`, then the lexicographically
-smallest surface as a deterministic tie-break.
-
-`show --format json` adds a `term_preferences` array (the text output stays a
-short provenance summary):
-
-```jsonc
-"term_preferences": [
-  {
-    "group_key": "term:db",
-    "preferred_surface": "DB",
-    "doc_count": 2,
-    "total_count": 7,
-    "variants": [
-      { "surface": "DB", "normalized_key": "db", "count": 5, "doc_count": 2 },
-      { "surface": "データベース", "normalized_key": "データベース", "count": 2, "doc_count": 1 }
-    ]
-  }
-]
-```
-
-`check --format json` adds a `term_warnings` array for any surface in the draft
-that differs from the group's preferred one. It is a **separate layer from the
-similarity score and never changes it**:
-
-```jsonc
-"term_warnings": [
-  { "group_key": "term:db", "preferred_surface": "DB", "used_surface": "ＤＢ", "count": 1 }
-]
-```
-
-(`occurrences` with line/column information is a reserved, optional field for a
-future version; only counts are reported today.) Term preferences appear only in
-the JSON output, so plain `check` stays fast and unchanged. Candidate extraction
-is intentionally lightweight — Japanese kanji/katakana runs and ASCII words and
-acronyms; half-width katakana and semantic synonyms without a corpus-declared
-bridge are out of scope for now.
+`show --format json` adds `term_preferences` (group, preferred surface, counts,
+and variants). `check --format json` adds `term_warnings` for any draft surface
+that differs from its group's preferred form; this is a separate layer that never
+changes the similarity score. Both appear only in JSON, so plain `check` is
+unchanged. Extraction is intentionally lightweight; half-width katakana and
+synonyms without a corpus-declared bridge are out of scope.
 
 ## Choosing the author
 

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -19,6 +19,7 @@ import (
 	"github.com/nao1215/omokage/internal/profile"
 	"github.com/nao1215/omokage/internal/project"
 	"github.com/nao1215/omokage/internal/storage"
+	"github.com/nao1215/omokage/internal/term"
 )
 
 // Output formats for `check`. text is the default human-readable report; json
@@ -373,6 +374,17 @@ func (a *App) runTrain(args []string) int {
 		return 1
 	}
 
+	// Term preferences are a separate, profile-local layer extracted from the same
+	// files (no LLM, no network). They are stored in the same database next to the
+	// style distribution. Failing to write them is reported but does not undo the
+	// trained profile, which is already saved and valid on its own.
+	terms, err := term.ExtractCorpus(files)
+	if err != nil {
+		writef(a.stderr, "warning: the profile was trained, but extracting term preferences failed: %v\n", err)
+	} else if err := storage.SaveTerms(profilePath, terms); err != nil {
+		writef(a.stderr, "warning: the profile was trained, but saving term preferences failed: %v\n", err)
+	}
+
 	writef(a.stdout, "Trained author %q from %d files.\n", record.Author, record.FileCount)
 	writef(a.stdout, "Profile: %s\n", profilePath)
 
@@ -503,7 +515,17 @@ func (a *App) runCheck(args []string) int {
 	}
 	explanation := profile.Explain(record.Distribution, targetMetrics, segments, scope.Config.Features)
 	if *format == formatJSON {
-		if err := renderExplanationJSON(a.stdout, record.Author, explanation); err != nil {
+		// Term warnings are a separate layer from the similarity score: they report
+		// where the draft used a non-preferred surface, and never alter the score.
+		// A failure to load or read terms degrades to no warnings rather than hiding
+		// the drift report.
+		var warnings []term.Warning
+		if terms, err := storage.LoadTerms(profilePath); err == nil {
+			if draft, err := os.ReadFile(filepath.Clean(targetPath)); err == nil {
+				warnings = terms.CheckText(string(draft))
+			}
+		}
+		if err := renderExplanationJSON(a.stdout, record.Author, explanation, warnings); err != nil {
 			writeLine(a.stderr, err)
 			return 1
 		}
@@ -698,16 +720,25 @@ func (a *App) runShow(args []string) int {
 	}
 
 	if *format == formatJSON {
+		// Term preferences are reported only in the JSON form (the text form stays a
+		// short provenance summary, not a term dump). A load failure here should not
+		// hide the rest of the profile, so it degrades to an empty list.
+		terms, err := storage.LoadTerms(profilePath)
+		if err != nil {
+			writeLine(a.stderr, err)
+			return 1
+		}
 		payload := profileSummaryJSON{
-			Author:         record.Author,
-			TrainedAt:      record.TrainedAt.Format(time.RFC3339),
-			FileCount:      record.FileCount,
-			SourceDir:      record.SourceDir,
-			Sources:        recordSources(record),
-			DocumentCount:  record.Distribution.DocumentCount,
-			SentenceCount:  record.Distribution.SentenceCount,
-			CharacterCount: record.Distribution.CharacterCount,
-			Default:        record.Author == strings.TrimSpace(scope.Config.Defaults.Author),
+			Author:          record.Author,
+			TrainedAt:       record.TrainedAt.Format(time.RFC3339),
+			FileCount:       record.FileCount,
+			SourceDir:       record.SourceDir,
+			Sources:         recordSources(record),
+			DocumentCount:   record.Distribution.DocumentCount,
+			SentenceCount:   record.Distribution.SentenceCount,
+			CharacterCount:  record.Distribution.CharacterCount,
+			Default:         record.Author == strings.TrimSpace(scope.Config.Defaults.Author),
+			TermPreferences: toTermPreferenceJSON(terms),
 		}
 		encoder := json.NewEncoder(a.stdout)
 		encoder.SetIndent("", "  ")
@@ -956,6 +987,54 @@ type profileSummaryJSON struct {
 	SentenceCount  int      `json:"sentence_count"`
 	CharacterCount int      `json:"character_count"`
 	Default        bool     `json:"default"`
+	// TermPreferences is the profile's learned notation preferences. It is always
+	// present (an empty array when none were extracted) so the shape is stable.
+	TermPreferences []termPreferenceJSON `json:"term_preferences"`
+}
+
+// termPreferenceJSON is one same-concept group in `show --format json`.
+type termPreferenceJSON struct {
+	GroupKey         string            `json:"group_key"`
+	PreferredSurface string            `json:"preferred_surface"`
+	DocCount         int               `json:"doc_count"`
+	TotalCount       int               `json:"total_count"`
+	Variants         []termVariantJSON `json:"variants"`
+}
+
+// termVariantJSON is one surface form within a term preference group. normalized_key
+// is reported separately from group_key so a reader can tell normalization merges
+// (same normalized_key) apart from alias-bridge merges (same group_key across
+// different normalized_keys).
+type termVariantJSON struct {
+	Surface       string `json:"surface"`
+	NormalizedKey string `json:"normalized_key"`
+	Count         int    `json:"count"`
+	DocCount      int    `json:"doc_count"`
+}
+
+// toTermPreferenceJSON converts the stored term profile into the show payload,
+// always returning a non-nil slice so the JSON shows an empty array, not null.
+func toTermPreferenceJSON(profile term.Profile) []termPreferenceJSON {
+	out := make([]termPreferenceJSON, 0, len(profile.Groups))
+	for _, group := range profile.Groups {
+		variants := make([]termVariantJSON, 0, len(group.Variants))
+		for _, v := range group.Variants {
+			variants = append(variants, termVariantJSON{
+				Surface:       v.Surface,
+				NormalizedKey: v.NormalizedKey,
+				Count:         v.Count,
+				DocCount:      v.DocCount,
+			})
+		}
+		out = append(out, termPreferenceJSON{
+			GroupKey:         group.GroupKey,
+			PreferredSurface: group.PreferredSurface,
+			DocCount:         group.DocCount,
+			TotalCount:       group.TotalCount,
+			Variants:         variants,
+		})
+	}
+	return out
 }
 
 // recordSources returns the learning sources of a profile, always non-empty for a

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -721,12 +721,14 @@ func (a *App) runShow(args []string) int {
 
 	if *format == formatJSON {
 		// Term preferences are reported only in the JSON form (the text form stays a
-		// short provenance summary, not a term dump). A load failure here should not
-		// hide the rest of the profile, so it degrades to an empty list.
+		// short provenance summary, not a term dump). They are auxiliary to the
+		// profile summary, so a load failure is reported on stderr but does not fail
+		// the command or corrupt the JSON on stdout: the summary is still emitted with
+		// an empty term list.
 		terms, err := storage.LoadTerms(profilePath)
 		if err != nil {
-			writeLine(a.stderr, err)
-			return 1
+			writef(a.stderr, "warning: could not load term preferences: %v\n", err)
+			terms = term.Profile{}
 		}
 		payload := profileSummaryJSON{
 			Author:          record.Author,

--- a/cmd/explain.go
+++ b/cmd/explain.go
@@ -7,6 +7,7 @@ import (
 	"math"
 
 	"github.com/nao1215/omokage/internal/profile"
+	"github.com/nao1215/omokage/internal/term"
 )
 
 // renderExplanationText prints the human-facing detailed report. It leads with
@@ -66,7 +67,7 @@ func renderExplanationText(w io.Writer, author string, explanation profile.Expla
 // be read back by an LLM in a revise-and-recheck loop: the high-level (editable)
 // drifts and the low-level fingerprint are kept in separate arrays, each carrying
 // the target value, reference mean and spread, z-score, and fix priority.
-func renderExplanationJSON(w io.Writer, author string, explanation profile.Explanation) error {
+func renderExplanationJSON(w io.Writer, author string, explanation profile.Explanation, warnings []term.Warning) error {
 	high, low := splitDrifts(explanation.Drifts)
 	payload := explanationJSON{
 		Author:         author,
@@ -74,6 +75,7 @@ func renderExplanationJSON(w io.Writer, author string, explanation profile.Expla
 		HighLevelDrift: toDriftJSON(high),
 		LowLevelDrift:  toDriftJSON(low),
 		Segments:       toSegmentJSON(explanation.Segments),
+		TermWarnings:   toTermWarningJSON(warnings),
 	}
 	encoder := json.NewEncoder(w)
 	encoder.SetIndent("", "  ")
@@ -86,6 +88,45 @@ type explanationJSON struct {
 	HighLevelDrift []featureDriftJSON `json:"high_level_drift"`
 	LowLevelDrift  []featureDriftJSON `json:"low_level_drift"`
 	Segments       []segmentJSON      `json:"segments"`
+	// TermWarnings reports notation deviations (a non-preferred surface in the
+	// draft). It is a separate layer from the similarity score and never affects
+	// it. Always present (empty array, not null) so the shape is stable.
+	TermWarnings []termWarningJSON `json:"term_warnings"`
+}
+
+// termWarningJSON is one notation deviation in `check --format json`. Occurrences
+// is reserved for future line/column reporting and is omitted while only counts
+// are tracked, so adding it later will not change existing fields.
+type termWarningJSON struct {
+	GroupKey         string               `json:"group_key"`
+	PreferredSurface string               `json:"preferred_surface"`
+	UsedSurface      string               `json:"used_surface"`
+	Count            int                  `json:"count"`
+	Occurrences      []termOccurrenceJSON `json:"occurrences,omitempty"`
+}
+
+type termOccurrenceJSON struct {
+	Line   int `json:"line"`
+	Column int `json:"column"`
+}
+
+// toTermWarningJSON converts term warnings into the check payload, always
+// returning a non-nil slice so the JSON shows an empty array rather than null.
+func toTermWarningJSON(warnings []term.Warning) []termWarningJSON {
+	out := make([]termWarningJSON, 0, len(warnings))
+	for _, w := range warnings {
+		warning := termWarningJSON{
+			GroupKey:         w.GroupKey,
+			PreferredSurface: w.PreferredSurface,
+			UsedSurface:      w.UsedSurface,
+			Count:            w.Count,
+		}
+		for _, occ := range w.Occurrences {
+			warning.Occurrences = append(warning.Occurrences, termOccurrenceJSON{Line: occ.Line, Column: occ.Column})
+		}
+		out = append(out, warning)
+	}
+	return out
 }
 
 type featureDriftJSON struct {

--- a/cmd/term_test.go
+++ b/cmd/term_test.go
@@ -1,0 +1,153 @@
+package cmd
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The structs below mirror the term-related portions of the show/check JSON
+// payloads so the end-to-end test reads the new fields back the way a consumer
+// would.
+
+type showTermVariant struct {
+	Surface       string `json:"surface"`
+	NormalizedKey string `json:"normalized_key"`
+	Count         int    `json:"count"`
+	DocCount      int    `json:"doc_count"`
+}
+
+type showTermGroup struct {
+	GroupKey         string            `json:"group_key"`
+	PreferredSurface string            `json:"preferred_surface"`
+	DocCount         int               `json:"doc_count"`
+	TotalCount       int               `json:"total_count"`
+	Variants         []showTermVariant `json:"variants"`
+}
+
+type showTermsPayload struct {
+	TermPreferences []showTermGroup `json:"term_preferences"`
+}
+
+type checkTermsPayload struct {
+	Similarity   int `json:"similarity"`
+	TermWarnings []struct {
+		GroupKey         string `json:"group_key"`
+		PreferredSurface string `json:"preferred_surface"`
+		UsedSurface      string `json:"used_surface"`
+		Count            int    `json:"count"`
+	} `json:"term_warnings"`
+}
+
+func findShowGroup(p showTermsPayload, preferred string) *showTermGroup {
+	for i := range p.TermPreferences {
+		if p.TermPreferences[i].PreferredSurface == preferred {
+			return &p.TermPreferences[i]
+		}
+	}
+	return nil
+}
+
+func groupHasSurface(g *showTermGroup, surface string) bool {
+	for _, v := range g.Variants {
+		if v.Surface == surface {
+			return true
+		}
+	}
+	return false
+}
+
+// TestTermPreferencesEndToEnd exercises the full feature through the CLI:
+// train extracts term preferences, show --format json reports them (including a
+// corpus-declared alias bridge), and check --format json flags a draft that uses
+// a non-preferred surface — without changing the similarity score.
+func TestTermPreferencesEndToEnd(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+	corpusDir := filepath.Join(workDir, "posts")
+	// DB is used far more than データベース, so DB becomes the preferred surface;
+	// the parenthetical "データベース（DB）" declares the alias bridge.
+	writeTestFile(t, filepath.Join(corpusDir, "one.md"),
+		"データベース（DB）を使う。DB は速い。DB を使う。DB が良い。")
+	writeTestFile(t, filepath.Join(corpusDir, "two.md"),
+		"DB を使う。DB が好き。DB を選ぶ。データベースも使う。")
+
+	if code, _, stderr := runApp(t, workDir, "init"); code != 0 {
+		t.Fatalf("init failed: %s", stderr)
+	}
+	if code, _, stderr := runApp(t, workDir, "train", "--author", "me", "posts"); code != 0 {
+		t.Fatalf("train failed: %s", stderr)
+	}
+
+	// show --format json must surface the bridged DB/データベース group.
+	code, stdout, stderr := runApp(t, workDir, "show", "--author", "me", "--format", "json")
+	if code != 0 {
+		t.Fatalf("show --format json failed: %s", stderr)
+	}
+	var show showTermsPayload
+	if err := json.Unmarshal([]byte(stdout), &show); err != nil {
+		t.Fatalf("show JSON invalid: %v\n%s", err, stdout)
+	}
+	dbGroup := findShowGroup(show, "DB")
+	if dbGroup == nil {
+		t.Fatalf("expected a term preference group with preferred surface DB:\n%s", stdout)
+	}
+	if !groupHasSurface(dbGroup, "データベース") {
+		t.Errorf("expected データベース to be bridged into the DB group, got %+v", dbGroup)
+	}
+	keys := map[string]struct{}{}
+	for _, v := range dbGroup.Variants {
+		keys[v.NormalizedKey] = struct{}{}
+	}
+	if len(keys) < 2 {
+		t.Errorf("bridged group should span >1 normalized_key, got %v", keys)
+	}
+
+	// check --format json must flag a draft that uses the non-preferred surface.
+	writeTestFile(t, filepath.Join(workDir, "draft.md"), "ＤＢ を整備する。データベースを設計する。")
+	code, stdout, stderr = runApp(t, workDir, "check", "--author", "me", "--format", "json", "draft.md")
+	if code != 0 {
+		t.Fatalf("check --format json failed: %s", stderr)
+	}
+	var check checkTermsPayload
+	if err := json.Unmarshal([]byte(stdout), &check); err != nil {
+		t.Fatalf("check JSON invalid: %v\n%s", err, stdout)
+	}
+	if len(check.TermWarnings) == 0 {
+		t.Fatalf("expected term warnings for ＤＢ/データベース, got none:\n%s", stdout)
+	}
+	for _, w := range check.TermWarnings {
+		if w.PreferredSurface != "DB" {
+			t.Errorf("warning %+v should point at preferred surface DB", w)
+		}
+		if w.UsedSurface == "DB" {
+			t.Errorf("the preferred surface must never be flagged: %+v", w)
+		}
+	}
+
+	// The plain (text) check must keep working and stay unaffected by the warnings
+	// layer: it still reports output and exits 0.
+	if code, plain, stderr := runApp(t, workDir, "check", "--author", "me", "draft.md"); code != 0 {
+		t.Fatalf("plain check failed: %s", stderr)
+	} else if !strings.Contains(plain, "Similarity") {
+		t.Fatalf("plain check should still report a similarity line, got %q", plain)
+	}
+}
+
+// TestShowJSONTermPreferencesAlwaysPresent checks the shape stays stable: even a
+// corpus with no extractable bridged terms still emits a term_preferences array,
+// not null.
+func TestShowJSONTermPreferencesAlwaysPresent(t *testing.T) {
+	t.Parallel()
+
+	workDir := trainedProject(t)
+	code, stdout, stderr := runApp(t, workDir, "show", "--author", "me", "--format", "json")
+	if code != 0 {
+		t.Fatalf("show --format json failed: %s", stderr)
+	}
+	if !strings.Contains(stdout, `"term_preferences"`) {
+		t.Fatalf("term_preferences must always be present:\n%s", stdout)
+	}
+}

--- a/internal/feature/ngram.go
+++ b/internal/feature/ngram.go
@@ -58,6 +58,14 @@ var inlineCodePattern = regexp.MustCompile("`[^`]*`")
 // markers are recognized — backtick (``` … ```) and tilde (~~~ … ~~~) — and a
 // block is closed only by its own marker, so a tilde line inside a backtick
 // block (or vice versa) is treated as content, not a boundary.
+// StripCode removes fenced and inline code from text and returns the remaining
+// prose. It is the exported entry point other packages (e.g. term extraction)
+// use to measure prose only, exactly as the feature extractor does, after
+// normalizing CRLF line endings.
+func StripCode(text string) string {
+	return stripCode(strings.ReplaceAll(text, "\r\n", "\n"))
+}
+
 func stripCode(text string) string {
 	lines := strings.Split(text, "\n")
 	kept := make([]string, 0, len(lines))

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -57,6 +57,28 @@ CREATE TABLE IF NOT EXISTS profile (
   mean_char_ngrams TEXT NOT NULL DEFAULT '{}',
   std_char_ngrams TEXT NOT NULL DEFAULT '{}',
   sources TEXT NOT NULL DEFAULT '[]'
+);
+
+-- Term preferences are profile-local: this database holds exactly one author's
+-- profile, so these tables describe only that author's notation choices. No
+-- profile_id column is needed. normalized_key and group_key are kept as separate
+-- columns so a reader can tell whether two surfaces were merged by plain
+-- normalization (same normalized_key) or by a corpus-declared alias bridge (same
+-- group_key spanning different normalized_keys). Original training text is never
+-- stored — only surfaces and their counts.
+CREATE TABLE IF NOT EXISTS term_group (
+  group_key TEXT PRIMARY KEY,
+  preferred_surface TEXT NOT NULL,
+  total_count INTEGER NOT NULL,
+  doc_count INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS term_variant (
+  group_key TEXT NOT NULL,
+  normalized_key TEXT NOT NULL,
+  surface TEXT NOT NULL,
+  count INTEGER NOT NULL,
+  doc_count INTEGER NOT NULL,
+  PRIMARY KEY (group_key, surface)
 );`
 
 // migrate brings an existing profile database up to the current schema. The

--- a/internal/storage/terms.go
+++ b/internal/storage/terms.go
@@ -1,0 +1,155 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/nao1215/omokage/internal/term"
+)
+
+// SaveTerms persists a profile's term preferences into the same per-author
+// database used by SaveProfile. The data is profile-local: this file holds one
+// author, so the term tables describe only that author. A re-train replaces the
+// previous term data wholesale, inside a transaction, so a reader never sees a
+// half-written mix of old and new groups.
+func SaveTerms(path string, profile term.Profile) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return err
+	}
+	ctx := context.Background()
+	db, err := openDB(ctx, path)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	// Rollback after a successful Commit is a no-op; the error only matters on the
+	// failure paths, where Commit was never reached.
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, `DELETE FROM term_variant`); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM term_group`); err != nil {
+		return err
+	}
+
+	for _, group := range profile.Groups {
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO term_group (group_key, preferred_surface, total_count, doc_count) VALUES (?, ?, ?, ?)`,
+			group.GroupKey, group.PreferredSurface, group.TotalCount, group.DocCount,
+		); err != nil {
+			return err
+		}
+		for _, variant := range group.Variants {
+			if _, err := tx.ExecContext(ctx,
+				`INSERT INTO term_variant (group_key, normalized_key, surface, count, doc_count) VALUES (?, ?, ?, ?, ?)`,
+				variant.GroupKey, variant.NormalizedKey, variant.Surface, variant.Count, variant.DocCount,
+			); err != nil {
+				return err
+			}
+		}
+	}
+	return tx.Commit()
+}
+
+// LoadTerms reads a profile's term preferences. A profile trained before term
+// support (or one with no extracted terms) simply yields an empty profile, never
+// an error, so show/check degrade gracefully. The returned groups and their
+// variants are ordered deterministically (group_key ascending; variants by
+// descending count then surface).
+func LoadTerms(path string) (term.Profile, error) {
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return term.Profile{}, nil
+		}
+		return term.Profile{}, err
+	}
+	ctx := context.Background()
+	db, err := openDB(ctx, path)
+	if err != nil {
+		return term.Profile{}, err
+	}
+	defer db.Close()
+
+	variantsByGroup, err := loadVariants(ctx, db)
+	if err != nil {
+		return term.Profile{}, err
+	}
+
+	rows, err := db.QueryContext(ctx,
+		`SELECT group_key, preferred_surface, total_count, doc_count FROM term_group ORDER BY group_key`)
+	if err != nil {
+		return term.Profile{}, err
+	}
+	defer rows.Close()
+
+	var groups []term.Group
+	for rows.Next() {
+		var g term.Group
+		if err := rows.Scan(&g.GroupKey, &g.PreferredSurface, &g.TotalCount, &g.DocCount); err != nil {
+			return term.Profile{}, err
+		}
+		g.Variants = variantsByGroup[g.GroupKey]
+		groups = append(groups, g)
+	}
+	if err := rows.Err(); err != nil {
+		return term.Profile{}, err
+	}
+	return term.Profile{Groups: groups}, nil
+}
+
+func loadVariants(ctx context.Context, db *sql.DB) (map[string][]term.Variant, error) {
+	rows, err := db.QueryContext(ctx,
+		`SELECT group_key, normalized_key, surface, count, doc_count FROM term_variant ORDER BY group_key, count DESC, surface`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make(map[string][]term.Variant)
+	for rows.Next() {
+		var v term.Variant
+		if err := rows.Scan(&v.GroupKey, &v.NormalizedKey, &v.Surface, &v.Count, &v.DocCount); err != nil {
+			return nil, err
+		}
+		out[v.GroupKey] = append(out[v.GroupKey], v)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	for _, variants := range out {
+		sort.SliceStable(variants, func(i, j int) bool {
+			if variants[i].Count != variants[j].Count {
+				return variants[i].Count > variants[j].Count
+			}
+			return variants[i].Surface < variants[j].Surface
+		})
+	}
+	return out, nil
+}
+
+// openDB opens the profile database and ensures the current schema (including the
+// term tables) and migrations are applied, matching SaveProfile/LoadProfile.
+func openDB(ctx context.Context, path string) (*sql.DB, error) {
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := db.ExecContext(ctx, schema); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	if err := migrate(ctx, db); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return db, nil
+}

--- a/internal/storage/terms_test.go
+++ b/internal/storage/terms_test.go
@@ -1,0 +1,137 @@
+package storage
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/nao1215/omokage/internal/profile"
+	"github.com/nao1215/omokage/internal/term"
+)
+
+func sampleTermProfile() term.Profile {
+	return term.Profile{
+		Groups: []term.Group{
+			{
+				GroupKey:         "term:ci",
+				PreferredSurface: "継続的インテグレーション",
+				TotalCount:       9,
+				DocCount:         3,
+				Variants: []term.Variant{
+					{Surface: "継続的インテグレーション", NormalizedKey: "継続的インテグレーション", GroupKey: "term:ci", Count: 6, DocCount: 3},
+					{Surface: "CI", NormalizedKey: "ci", GroupKey: "term:ci", Count: 3, DocCount: 2},
+				},
+			},
+			{
+				GroupKey:         "term:db",
+				PreferredSurface: "DB",
+				TotalCount:       5,
+				DocCount:         2,
+				Variants: []term.Variant{
+					{Surface: "DB", NormalizedKey: "db", GroupKey: "term:db", Count: 4, DocCount: 2},
+					{Surface: "ＤＢ", NormalizedKey: "db", GroupKey: "term:db", Count: 1, DocCount: 1},
+				},
+			},
+		},
+	}
+}
+
+// TestSaveLoadTerms round-trips a term profile through the database and checks
+// every field survives, including the separation of normalized_key (db for both
+// DB and ＤＢ) from group_key.
+func TestSaveLoadTerms(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "profiles", "nao.db")
+	want := sampleTermProfile()
+	if err := SaveTerms(path, want); err != nil {
+		t.Fatalf("SaveTerms: %v", err)
+	}
+
+	got, err := LoadTerms(path)
+	if err != nil {
+		t.Fatalf("LoadTerms: %v", err)
+	}
+	if len(got.Groups) != len(want.Groups) {
+		t.Fatalf("group count = %d, want %d", len(got.Groups), len(want.Groups))
+	}
+	for i, wg := range want.Groups {
+		gg := got.Groups[i]
+		if gg.GroupKey != wg.GroupKey || gg.PreferredSurface != wg.PreferredSurface ||
+			gg.TotalCount != wg.TotalCount || gg.DocCount != wg.DocCount {
+			t.Errorf("group %d = %+v, want %+v", i, gg, wg)
+		}
+		if len(gg.Variants) != len(wg.Variants) {
+			t.Fatalf("group %d variant count = %d, want %d", i, len(gg.Variants), len(wg.Variants))
+		}
+		for j, wv := range wg.Variants {
+			if gg.Variants[j] != wv {
+				t.Errorf("group %d variant %d = %+v, want %+v", i, j, gg.Variants[j], wv)
+			}
+		}
+	}
+}
+
+// TestSaveTermsReplacesPrevious checks that re-saving replaces the prior term
+// data wholesale rather than accumulating stale groups.
+func TestSaveTermsReplacesPrevious(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "profiles", "nao.db")
+	if err := SaveTerms(path, sampleTermProfile()); err != nil {
+		t.Fatal(err)
+	}
+	replacement := term.Profile{Groups: []term.Group{{
+		GroupKey: "term:api", PreferredSurface: "API", TotalCount: 2, DocCount: 1,
+		Variants: []term.Variant{{Surface: "API", NormalizedKey: "api", GroupKey: "term:api", Count: 2, DocCount: 1}},
+	}}}
+	if err := SaveTerms(path, replacement); err != nil {
+		t.Fatal(err)
+	}
+	got, err := LoadTerms(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Groups) != 1 || got.Groups[0].GroupKey != "term:api" {
+		t.Fatalf("expected only the replacement group, got %+v", got.Groups)
+	}
+}
+
+// TestLoadTermsMissingFile returns an empty profile (not an error) so show/check
+// can run against an author trained before term support existed.
+func TestLoadTermsMissingFile(t *testing.T) {
+	t.Parallel()
+
+	got, err := LoadTerms(filepath.Join(t.TempDir(), "absent.db"))
+	if err != nil {
+		t.Fatalf("LoadTerms on a missing file should not error: %v", err)
+	}
+	if len(got.Groups) != 0 {
+		t.Fatalf("expected an empty profile, got %+v", got.Groups)
+	}
+}
+
+// TestLoadTermsFromProfileWithoutTerms checks that a database created by
+// SaveProfile alone (no terms) loads as an empty term profile through the term
+// tables added by the schema migration, never an error.
+func TestLoadTermsFromProfileWithoutTerms(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "profiles", "nao.db")
+	record := profile.Record{
+		Author:    "nao",
+		SourceDir: "/tmp/corpus",
+		TrainedAt: time.Date(2026, time.June, 1, 12, 0, 0, 0, time.UTC),
+		FileCount: 1,
+	}
+	if err := SaveProfile(path, record); err != nil {
+		t.Fatal(err)
+	}
+	got, err := LoadTerms(path)
+	if err != nil {
+		t.Fatalf("LoadTerms on a terms-less profile should not error: %v", err)
+	}
+	if len(got.Groups) != 0 {
+		t.Fatalf("expected an empty term profile, got %+v", got.Groups)
+	}
+}

--- a/internal/storage/terms_test.go
+++ b/internal/storage/terms_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -108,6 +109,20 @@ func TestLoadTermsMissingFile(t *testing.T) {
 	}
 	if len(got.Groups) != 0 {
 		t.Fatalf("expected an empty profile, got %+v", got.Groups)
+	}
+}
+
+// TestLoadTermsCorruptFile checks that a non-database file is reported as an
+// error (the caller degrades to an empty list), not loaded as empty.
+func TestLoadTermsCorruptFile(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "broken.db")
+	if err := os.WriteFile(path, []byte("this is not a sqlite database"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadTerms(path); err == nil {
+		t.Fatal("expected an error loading a corrupt database file")
 	}
 }
 

--- a/internal/term/aliasbridge.go
+++ b/internal/term/aliasbridge.go
@@ -1,0 +1,146 @@
+package term
+
+import (
+	"regexp"
+	"strings"
+)
+
+// aliasLink is a corpus-declared bridge between a spelled-out Japanese phrase and
+// its acronym, e.g. phrase="データベース", acronym="db" from "データベース（DB）".
+// The two sides are kept distinct (not just an unordered pair) so the extractor
+// can detect an ambiguous acronym that glosses several different phrases and
+// refuse to chain them together.
+type aliasLink struct {
+	phrase  string
+	acronym string
+}
+
+// Bridge sizing. Detection is deliberately narrow: one side must be a genuine
+// Japanese phrase (kanji/katakana), the other a short UPPERCASE ASCII acronym
+// (DB, API, HTTP, OSS). This is the "長い日本語語句 + 英字略語" pattern the spec
+// centers on. Two ordinary words, two long phrases, or two lowercase words never
+// link, which also stops a shared short word from transitively chaining many
+// unrelated terms into one giant group.
+const (
+	minLongJapaneseLen = 3
+	minAcronymLen      = 2
+	maxAcronymLen      = 8
+)
+
+// parenBridge matches a term immediately followed by a parenthesized gloss, in
+// either ASCII or full-width parentheses. The left side is captured greedily as a
+// trailing ASCII/Japanese run; the inside is captured raw so the "以下" forms can
+// be handled separately. It is only a coarse candidate matcher — bridge()
+// applies the real Japanese-phrase ↔ acronym test. Examples it feeds to bridge():
+//
+//	データベース（DB）   DB（データベース）   データベース（以下 DB）
+//
+// An English-only pair like "database (DB)" is matched here but rejected by
+// bridge(): English phrase ↔ acronym is intentionally out of scope (it would
+// chain too eagerly), so only Japanese-phrase ↔ acronym pairs bridge.
+var parenBridge = regexp.MustCompile(`([\p{Han}\p{Katakana}ーA-Za-z0-9Ａ-Ｚａ-ｚ０-９]+)\s*[（(]([^）)]*)[）)]`)
+
+// inlineBridge matches the no-parenthesis "X。以下、Y" abbreviation declaration,
+// e.g. "データベース。以下、DB" or "データベース。以下DB".
+var inlineBridge = regexp.MustCompile(`([\p{Han}\p{Katakana}ーA-Za-z0-9Ａ-Ｚａ-ｚ０-９]{2,})。\s*以下[、,]?\s*([A-Za-zＡ-Ｚａ-ｚ][\p{Han}\p{Katakana}ーA-Za-z0-9Ａ-Ｚａ-ｚ０-９]*)`)
+
+// detectAliasLinks scans prose for conservative, corpus-declared alias bridges
+// and returns the normalized_key links they imply. It never infers a bridge from
+// a bare "A（B）"; one side must be a long phrase and the other a short ASCII
+// abbreviation (the orientation may be either way around), or the text must use
+// an explicit "以下 X" declaration.
+func detectAliasLinks(prose string) []aliasLink {
+	var links []aliasLink
+
+	for _, m := range parenBridge.FindAllStringSubmatch(prose, -1) {
+		left := m[1]
+		inner := strings.TrimSpace(m[2])
+		if rest, ok := stripIfuka(inner); ok {
+			// "以下 DB" explicitly declares DB as the abbreviation of left.
+			if link, ok := bridge(left, rest); ok {
+				links = append(links, link)
+			}
+			continue
+		}
+		if link, ok := bridge(left, inner); ok {
+			links = append(links, link)
+		}
+	}
+
+	for _, m := range inlineBridge.FindAllStringSubmatch(prose, -1) {
+		if link, ok := bridge(m[1], m[2]); ok {
+			links = append(links, link)
+		}
+	}
+
+	return links
+}
+
+// stripIfuka strips a leading "以下" (optionally followed by "、" or ",") from a
+// parenthetical gloss, reporting whether it was present. "以下 DB" -> "DB".
+func stripIfuka(s string) (string, bool) {
+	if !strings.HasPrefix(s, "以下") {
+		return s, false
+	}
+	rest := strings.TrimPrefix(s, "以下")
+	rest = strings.TrimLeft(rest, "、, \t")
+	return strings.TrimSpace(rest), true
+}
+
+// bridge validates that one side is a long Japanese phrase and the other a short
+// uppercase ASCII acronym (in either order) and, if so, returns the
+// normalized_key link between them. A pair of ordinary words, two phrases, or a
+// lowercase word is rejected, so a bare "A（B）" never links and shared short
+// words cannot chain unrelated terms together.
+func bridge(left, right string) (aliasLink, bool) {
+	lk := normalizeKey(left)
+	rk := normalizeKey(right)
+	if lk == "" || rk == "" || lk == rk {
+		return aliasLink{}, false
+	}
+	if isJapanesePhrase(left) && isAcronym(right) {
+		return aliasLink{phrase: lk, acronym: rk}, true
+	}
+	if isAcronym(left) && isJapanesePhrase(right) {
+		return aliasLink{phrase: rk, acronym: lk}, true
+	}
+	return aliasLink{}, false
+}
+
+// isJapanesePhrase reports whether a surface is a long-enough Japanese term: at
+// least minLongJapaneseLen kanji/katakana runes and no ASCII letters (so it is a
+// spelled-out word, not an acronym).
+func isJapanesePhrase(surface string) bool {
+	japanese := 0
+	for _, r := range surface {
+		switch {
+		case isJapaneseTermRune(r):
+			japanese++
+		case (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z'):
+			return false
+		}
+	}
+	return japanese >= minLongJapaneseLen
+}
+
+// isAcronym reports whether a surface looks like an English acronym: only
+// UPPERCASE ASCII letters and digits (after folding full-width forms), at least
+// one letter, within the length bound. DB, API, HTTP, OSS qualify; "Debian",
+// "linux", and "testing" do not, which is what keeps bridges from chaining.
+func isAcronym(surface string) bool {
+	runes := []rune(foldRune(strings.TrimFunc(surface, isTrimmable)))
+	if len(runes) < minAcronymLen || len(runes) > maxAcronymLen {
+		return false
+	}
+	hasLetter := false
+	for _, r := range runes {
+		switch {
+		case r >= 'A' && r <= 'Z':
+			hasLetter = true
+		case r >= '0' && r <= '9':
+		default:
+			return false
+		}
+	}
+	return hasLetter
+}

--- a/internal/term/candidate.go
+++ b/internal/term/candidate.go
@@ -1,0 +1,101 @@
+package term
+
+// minASCIILen is the shortest ASCII candidate kept. Two characters keeps the
+// common acronyms (DB, CI) while dropping single letters like "a" or "I".
+const minASCIILen = 2
+
+// minJapaneseLen is the shortest Japanese candidate kept, in runes. Two runes
+// keeps two-kanji compounds (文体) and short katakana words while dropping bare
+// single characters.
+const minJapaneseLen = 2
+
+// asciiStopwords are common English function words that are never useful as term
+// preferences. They are matched against the normalized_key (lower-cased), so the
+// scanner never emits them as candidates and they never form a group.
+var asciiStopwords = map[string]struct{}{
+	"a": {}, "an": {}, "the": {}, "and": {}, "or": {}, "but": {}, "of": {},
+	"to": {}, "in": {}, "on": {}, "at": {}, "by": {}, "for": {}, "with": {},
+	"as": {}, "is": {}, "are": {}, "was": {}, "were": {}, "be": {}, "been": {},
+	"it": {}, "its": {}, "this": {}, "that": {}, "these": {}, "those": {},
+	"from": {}, "into": {}, "than": {}, "then": {}, "so": {}, "if": {}, "we": {},
+	"you": {}, "they": {}, "he": {}, "she": {}, "i": {}, "my": {}, "our": {},
+	"your": {}, "their": {}, "do": {}, "does": {}, "did": {}, "not": {},
+	"no": {}, "can": {}, "will": {}, "would": {}, "should": {}, "could": {},
+}
+
+// scanCandidates walks prose once and returns the surface of every term
+// candidate, in order, with duplicates preserved so the caller can count
+// occurrences. Code must already be stripped by the caller.
+//
+// Two kinds of run are emitted:
+//
+//   - ASCII-like runs: ASCII or full-width ASCII letters/digits, length ≥
+//     minASCIILen, containing at least one letter, and not a stopword. This
+//     captures DB, API, HTTP, GoReleaser, database, priority.
+//   - Japanese runs: kanji/katakana (with ー), length ≥ minJapaneseLen. This
+//     captures データベース, 優先度, 文体, 東京タワー.
+//
+// A run ends at any rune of the other class or at any other character (spaces,
+// punctuation, hiragana), so "データベースDB" yields the two candidates
+// "データベース" and "DB".
+func scanCandidates(prose string) []string {
+	runes := []rune(prose)
+	out := make([]string, 0, len(runes)/4)
+	for i := 0; i < len(runes); {
+		switch {
+		case isASCIILike(runes[i]):
+			j := i
+			for j < len(runes) && isASCIILike(runes[j]) {
+				j++
+			}
+			surface := string(runes[i:j])
+			if keepASCII(surface) {
+				out = append(out, surface)
+			}
+			i = j
+		case isJapaneseTermRune(runes[i]):
+			j := i
+			for j < len(runes) && isJapaneseTermRune(runes[j]) {
+				j++
+			}
+			if j-i >= minJapaneseLen {
+				out = append(out, string(runes[i:j]))
+			}
+			i = j
+		default:
+			i++
+		}
+	}
+	return out
+}
+
+// keepASCII reports whether an ASCII-like run is worth keeping as a candidate:
+// long enough, holding at least one letter (so "2026" is dropped), and not a
+// stopword.
+func keepASCII(surface string) bool {
+	key := normalizeKey(surface)
+	if len([]rune(key)) < minASCIILen {
+		return false
+	}
+	hasLetter := false
+	for _, r := range key {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
+			hasLetter = true
+			break
+		}
+	}
+	if !hasLetter {
+		return false
+	}
+	_, stop := asciiStopwords[key]
+	return !stop
+}
+
+// surfaceCounts tallies surface occurrences within a single document.
+func surfaceCounts(prose string) map[string]int {
+	counts := make(map[string]int)
+	for _, surface := range scanCandidates(prose) {
+		counts[surface]++
+	}
+	return counts
+}

--- a/internal/term/check.go
+++ b/internal/term/check.go
@@ -1,0 +1,69 @@
+package term
+
+import (
+	"sort"
+
+	"github.com/nao1215/omokage/internal/feature"
+)
+
+// CheckText reports where a draft uses a surface other than the preferred one for
+// a term the profile knows. It is a separate layer from the style similarity
+// score: it never changes the score, it only surfaces notation deviations.
+//
+// Matching is by normalized_key: a draft surface is mapped to its group through
+// the variants' normalized_keys, so a draft that types "db" or the bridged
+// "データベース" is flagged against a profile that prefers "DB". A surface that
+// equals the group's preferred surface is not flagged. Occurrences is left empty
+// for now; only counts are reported.
+func (p Profile) CheckText(text string) []Warning {
+	if len(p.Groups) == 0 {
+		return nil
+	}
+	groupByKey := make(map[string]Group, len(p.Groups))
+	groupKeyForNorm := make(map[string]string)
+	for _, g := range p.Groups {
+		groupByKey[g.GroupKey] = g
+		for _, v := range g.Variants {
+			// Extraction guarantees one normalized_key maps to one group, but a profile
+			// loaded from an external database might not. Keep the first mapping (groups
+			// arrive ordered by group_key) so a malformed store cannot make warnings
+			// non-deterministic.
+			if _, seen := groupKeyForNorm[v.NormalizedKey]; !seen {
+				groupKeyForNorm[v.NormalizedKey] = g.GroupKey
+			}
+		}
+	}
+
+	type usage struct {
+		groupKey string
+		surface  string
+	}
+	counts := make(map[usage]int)
+	for _, surface := range scanCandidates(stripNoise(feature.StripCode(text))) {
+		groupKey, ok := groupKeyForNorm[normalizeKey(surface)]
+		if !ok {
+			continue
+		}
+		if surface == groupByKey[groupKey].PreferredSurface {
+			continue
+		}
+		counts[usage{groupKey: groupKey, surface: surface}]++
+	}
+
+	warnings := make([]Warning, 0, len(counts))
+	for u, count := range counts {
+		warnings = append(warnings, Warning{
+			GroupKey:         u.groupKey,
+			PreferredSurface: groupByKey[u.groupKey].PreferredSurface,
+			UsedSurface:      u.surface,
+			Count:            count,
+		})
+	}
+	sort.Slice(warnings, func(i, j int) bool {
+		if warnings[i].GroupKey != warnings[j].GroupKey {
+			return warnings[i].GroupKey < warnings[j].GroupKey
+		}
+		return warnings[i].UsedSurface < warnings[j].UsedSurface
+	})
+	return warnings
+}

--- a/internal/term/extract.go
+++ b/internal/term/extract.go
@@ -1,0 +1,192 @@
+package term
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/nao1215/omokage/internal/feature"
+)
+
+// ExtractCorpus reads each file, strips code, and builds the profile-local term
+// preferences for the corpus. It mirrors feature.ExtractCorpus so train can hand
+// it the same file list. It uses no LLM, network, or external dictionary.
+func ExtractCorpus(paths []string) (Profile, error) {
+	docs := make([]string, 0, len(paths))
+	for _, path := range paths {
+		data, err := os.ReadFile(filepath.Clean(path))
+		if err != nil {
+			return Profile{}, fmt.Errorf("read %s: %w", path, err)
+		}
+		docs = append(docs, string(data))
+	}
+	return ExtractDocuments(docs), nil
+}
+
+// ExtractDocuments builds term preferences from in-memory documents. It is the
+// deterministic core shared by ExtractCorpus and the tests:
+//
+//  1. count surface occurrences per document (code stripped first),
+//  2. collect corpus-declared alias links between normalized_keys,
+//  3. union normalized_keys into same-concept groups,
+//  4. assign each group a deterministic group_key and a preferred surface.
+func ExtractDocuments(docs []string) Profile {
+	totalCount := make(map[string]int)       // surface -> total occurrences
+	docsBySurface := make(map[string]intSet) // surface -> set of doc indices
+	keyOfSurface := make(map[string]string)  // surface -> normalized_key
+	uf := newUnionFind()
+	var links []aliasLink
+
+	for docIndex, doc := range docs {
+		prose := stripNoise(feature.StripCode(doc))
+		for surface, n := range surfaceCounts(prose) {
+			totalCount[surface] += n
+			if docsBySurface[surface] == nil {
+				docsBySurface[surface] = intSet{}
+			}
+			docsBySurface[surface][docIndex] = struct{}{}
+			key := normalizeKey(surface)
+			keyOfSurface[surface] = key
+			uf.add(key)
+		}
+		links = append(links, detectAliasLinks(prose)...)
+	}
+
+	mergeAliasLinks(uf, links)
+
+	groupKeys := assignGroupKeys(uf)
+
+	// Gather variants per group.
+	type groupAcc struct {
+		variants []Variant
+		docs     intSet
+	}
+	accs := make(map[string]*groupAcc)
+	for surface, key := range keyOfSurface {
+		groupKey := groupKeys[uf.find(key)]
+		acc := accs[groupKey]
+		if acc == nil {
+			acc = &groupAcc{docs: intSet{}}
+			accs[groupKey] = acc
+		}
+		acc.variants = append(acc.variants, Variant{
+			Surface:       surface,
+			NormalizedKey: key,
+			GroupKey:      groupKey,
+			Count:         totalCount[surface],
+			DocCount:      len(docsBySurface[surface]),
+		})
+		for docIndex := range docsBySurface[surface] {
+			acc.docs[docIndex] = struct{}{}
+		}
+	}
+
+	groups := make([]Group, 0, len(accs))
+	for groupKey, acc := range accs {
+		sortVariants(acc.variants)
+		total := 0
+		for _, v := range acc.variants {
+			total += v.Count
+		}
+		groups = append(groups, Group{
+			GroupKey:         groupKey,
+			PreferredSurface: preferredSurface(acc.variants),
+			TotalCount:       total,
+			DocCount:         len(acc.docs),
+			Variants:         acc.variants,
+		})
+	}
+	sort.Slice(groups, func(i, j int) bool { return groups[i].GroupKey < groups[j].GroupKey })
+	return Profile{Groups: groups}
+}
+
+// mergeAliasLinks unions the normalized_keys joined by corpus-declared bridges,
+// but only when both sides are unambiguous. An acronym that glosses several
+// different Japanese phrases (e.g. "データベース（DB）" and "ダッシュボード（DB）"
+// both reducing to "db"), or a phrase glossed by several different acronyms, is
+// ambiguous: merging through it would chain unrelated terms into one group, so
+// those links are dropped and the terms stay separate. This keeps the bridge
+// conservative — a shared short acronym never silently fuses distinct concepts.
+func mergeAliasLinks(uf *unionFind, links []aliasLink) {
+	phrasesByAcronym := make(map[string]map[string]struct{})
+	acronymsByPhrase := make(map[string]map[string]struct{})
+	for _, link := range links {
+		addToSet(phrasesByAcronym, link.acronym, link.phrase)
+		addToSet(acronymsByPhrase, link.phrase, link.acronym)
+	}
+	for _, link := range links {
+		uf.add(link.acronym)
+		uf.add(link.phrase)
+		if len(phrasesByAcronym[link.acronym]) == 1 && len(acronymsByPhrase[link.phrase]) == 1 {
+			uf.union(link.acronym, link.phrase)
+		}
+	}
+}
+
+func addToSet(m map[string]map[string]struct{}, key, value string) {
+	if m[key] == nil {
+		m[key] = make(map[string]struct{})
+	}
+	m[key][value] = struct{}{}
+}
+
+// assignGroupKeys gives every union-find component a deterministic group_key of
+// the form "term:<representative>", where the representative is the
+// lexicographically smallest normalized_key in the component. Choosing the
+// smallest key makes the id stable regardless of the order surfaces were seen.
+func assignGroupKeys(uf *unionFind) map[string]string {
+	rep := make(map[string]string) // root -> smallest key in component
+	for key := range uf.parent {
+		root := uf.find(key)
+		if cur, ok := rep[root]; !ok || key < cur {
+			rep[root] = key
+		}
+	}
+	out := make(map[string]string, len(rep))
+	for root, smallest := range rep {
+		out[root] = "term:" + smallest
+	}
+	return out
+}
+
+// preferredSurface picks a group's canonical spelling. The order is fixed and
+// must stay stable, because it is part of the documented contract and is pinned
+// by tests:
+//
+//  1. highest DocCount (used in the most documents),
+//  2. then highest Count (used most often),
+//  3. then the lexicographically smallest Surface, as a deterministic tie-break.
+func preferredSurface(variants []Variant) string {
+	best := variants[0]
+	for _, v := range variants[1:] {
+		if betterPreferred(v, best) {
+			best = v
+		}
+	}
+	return best.Surface
+}
+
+func betterPreferred(candidate, best Variant) bool {
+	switch {
+	case candidate.DocCount != best.DocCount:
+		return candidate.DocCount > best.DocCount
+	case candidate.Count != best.Count:
+		return candidate.Count > best.Count
+	default:
+		return candidate.Surface < best.Surface
+	}
+}
+
+// sortVariants orders a group's variants deterministically for storage and JSON
+// output: by descending count, then ascending surface.
+func sortVariants(variants []Variant) {
+	sort.Slice(variants, func(i, j int) bool {
+		if variants[i].Count != variants[j].Count {
+			return variants[i].Count > variants[j].Count
+		}
+		return variants[i].Surface < variants[j].Surface
+	})
+}
+
+type intSet map[int]struct{}

--- a/internal/term/extract_test.go
+++ b/internal/term/extract_test.go
@@ -1,0 +1,148 @@
+package term
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestExtractCorpusReadsFiles checks the file-reading entry point: counts are
+// aggregated across files and doc_count reflects how many files held a surface.
+func TestExtractCorpusReadsFiles(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	write := func(name, body string) string {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+	a := write("a.md", "DB を使う。DB は速い。")
+	b := write("b.md", "DB を使う。データベースも使う。")
+
+	p, err := ExtractCorpus([]string{a, b})
+	if err != nil {
+		t.Fatalf("ExtractCorpus: %v", err)
+	}
+	g := findGroup(p, "DB")
+	if g == nil {
+		t.Fatal("expected a DB group")
+	}
+	var db *Variant
+	for i := range g.Variants {
+		if g.Variants[i].Surface == "DB" {
+			db = &g.Variants[i]
+		}
+	}
+	if db == nil {
+		t.Fatal("expected a DB variant")
+	}
+	if db.Count != 3 || db.DocCount != 2 {
+		t.Fatalf("DB variant = count %d / doc_count %d, want 3 / 2", db.Count, db.DocCount)
+	}
+}
+
+// TestExtractCorpusReadError surfaces a read failure rather than silently
+// producing an empty profile.
+func TestExtractCorpusReadError(t *testing.T) {
+	t.Parallel()
+
+	_, err := ExtractCorpus([]string{filepath.Join(t.TempDir(), "does-not-exist.md")})
+	if err == nil {
+		t.Fatal("expected an error for a missing file")
+	}
+}
+
+// TestExtractDocumentsEmptyInputs checks that empty, whitespace-only, and
+// code-only documents yield no term groups (code is stripped before extraction).
+func TestExtractDocumentsEmptyInputs(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string][]string{
+		"empty":      {""},
+		"whitespace": {"   \n\n  \t "},
+		"code only":  {"```go\npackage main\nfunc main() { DB() }\n```"},
+	}
+	for name, docs := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if p := ExtractDocuments(docs); len(p.Groups) != 0 {
+				t.Fatalf("expected no groups for %s input, got %+v", name, p.Groups)
+			}
+		})
+	}
+}
+
+// TestStripNoiseExcludesURLsFrontmatterAndHTML checks that link URLs, YAML front
+// matter, and HTML tags never become term candidates, while visible prose does.
+func TestStripNoiseExcludesURLsFrontmatterAndHTML(t *testing.T) {
+	t.Parallel()
+
+	doc := "---\ntitle: foo\nimage: images/cover.jpg\n---\n\n" +
+		"詳しくは [データベース入門](https://example.com/db/intro.html) を参照。\n" +
+		`<img src="images/x.png" alt="DB">` + "\n\nデータベースは便利。"
+
+	p := ExtractDocuments([]string{doc})
+	for _, bad := range []string{"https", "com", "example", "jpg", "png", "images", "img", "src", "html", "title"} {
+		if g := findGroup(p, bad); g != nil {
+			t.Errorf("noise token %q must not be a candidate (group %s)", bad, g.GroupKey)
+		}
+	}
+	if findGroup(p, "データベース") == nil {
+		t.Error("visible prose term データベース should still be a candidate")
+	}
+}
+
+// TestGroupKeyIndependentOfUnionOrder checks that the deterministic group_key
+// (smallest normalized_key in the component) does not depend on the order links
+// are applied — both union directions must give the same id.
+func TestGroupKeyIndependentOfUnionOrder(t *testing.T) {
+	t.Parallel()
+
+	forward := newUnionFind()
+	for _, k := range []string{"db", "data", "store"} {
+		forward.add(k)
+	}
+	forward.union("db", "data")
+	forward.union("data", "store")
+
+	reverse := newUnionFind()
+	for _, k := range []string{"db", "data", "store"} {
+		reverse.add(k)
+	}
+	reverse.union("store", "data")
+	reverse.union("data", "db")
+
+	gf := assignGroupKeys(forward)
+	gr := assignGroupKeys(reverse)
+	for _, k := range []string{"db", "data", "store"} {
+		if gf[forward.find(k)] != "term:data" || gr[reverse.find(k)] != "term:data" {
+			t.Fatalf("group_key for %q: forward=%s reverse=%s, want term:data both", k, gf[forward.find(k)], gr[reverse.find(k)])
+		}
+	}
+}
+
+// TestCheckTextEmptyProfile checks that checking against a profile with no terms
+// returns no warnings rather than panicking.
+func TestCheckTextEmptyProfile(t *testing.T) {
+	t.Parallel()
+
+	if w := (Profile{}).CheckText("DB を使う。"); len(w) != 0 {
+		t.Fatalf("empty profile should produce no warnings, got %+v", w)
+	}
+}
+
+// TestKeepASCIIRejectsNoise pins the ASCII candidate filter: stopwords,
+// single-letter runs, and pure-digit runs are dropped; real tokens are kept.
+func TestKeepASCIIRejectsNoise(t *testing.T) {
+	t.Parallel()
+
+	kept := map[string]bool{"DB": true, "API": true, "GoReleaser": true, "the": false, "a": false, "2026": false}
+	for surface, want := range kept {
+		if got := keepASCII(surface); got != want {
+			t.Errorf("keepASCII(%q) = %v, want %v", surface, got, want)
+		}
+	}
+}

--- a/internal/term/noise.go
+++ b/internal/term/noise.go
@@ -1,0 +1,33 @@
+package term
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	// frontmatter matches a leading YAML front-matter block (Hugo/Jekyll posts),
+	// whose paths and metadata are not prose and would otherwise flood the
+	// candidates with "images", "jpg", "post", and the like.
+	frontmatter = regexp.MustCompile(`(?s)\A\s*---\n.*?\n---\n`)
+	// markdownLink keeps a link/image's visible text and drops its URL, so a link
+	// target never contributes URL fragments (https, com, jp) as candidates.
+	markdownLink = regexp.MustCompile(`!?\[([^\]]*)\]\([^)]*\)`)
+	htmlTag      = regexp.MustCompile(`<[^>]*>`)
+	url          = regexp.MustCompile(`https?://\S+`)
+	htmlEntity   = regexp.MustCompile(`&[a-zA-Z]+;`)
+)
+
+// stripNoise removes non-prose that survives code stripping but should never
+// become a term candidate or feed an alias bridge: YAML front matter, link/image
+// URLs, raw URLs, HTML tags, and HTML entities. It is deterministic and adds no
+// dependency. Visible link text is preserved so real terms inside links still
+// count.
+func stripNoise(text string) string {
+	text = frontmatter.ReplaceAllString(text, "")
+	text = markdownLink.ReplaceAllString(text, "$1")
+	text = url.ReplaceAllString(text, " ")
+	text = htmlTag.ReplaceAllString(text, " ")
+	text = htmlEntity.ReplaceAllString(text, " ")
+	return strings.TrimSpace(text)
+}

--- a/internal/term/normalize.go
+++ b/internal/term/normalize.go
@@ -1,0 +1,73 @@
+package term
+
+import (
+	"strings"
+	"unicode"
+)
+
+// normalizeKey folds a surface into its deterministic normalized_key. The fold
+// is intentionally limited to changes that never alter meaning, so two surfaces
+// share a normalized_key only when they are genuinely the same spelling:
+//
+//   - surrounding punctuation, brackets, and whitespace are trimmed,
+//   - full-width ASCII letters/digits (Ａ-Ｚ ａ-ｚ ０-９) collapse to ASCII,
+//   - ASCII letters are lower-cased.
+//
+// So DB, db, and ＤＢ all normalize to "db". Japanese text is left as-is (data
+// stays データベース): folding kana would risk merging distinct words, which is
+// out of scope for this conservative initial implementation. Half-width katakana
+// is not folded for the same reason (see the package limitations in the README).
+func normalizeKey(surface string) string {
+	folded := make([]rune, 0, len(surface))
+	for _, r := range foldRune(surface) {
+		folded = append(folded, r)
+	}
+	trimmed := strings.TrimFunc(string(folded), isTrimmable)
+	return strings.ToLower(trimmed)
+}
+
+// foldRune returns surface with full-width ASCII folded to ASCII. It is split
+// out so candidate scanning can recognize ＤＢ as an ASCII-like run while keeping
+// the original surface intact.
+func foldRune(surface string) string {
+	var b strings.Builder
+	b.Grow(len(surface))
+	for _, r := range surface {
+		b.WriteRune(foldWidth(r))
+	}
+	return b.String()
+}
+
+// foldWidth maps a single full-width ASCII rune to its half-width ASCII form and
+// leaves every other rune unchanged.
+func foldWidth(r rune) rune {
+	if r >= '！' && r <= '～' { // U+FF01..U+FF5E -> U+0021..U+007E
+		return r - 0xFEE0
+	}
+	return r
+}
+
+// isTrimmable reports whether a rune should be stripped from the edges of a
+// surface when forming its normalized_key: spaces, and leading/trailing
+// punctuation or symbols such as brackets and quotation marks.
+func isTrimmable(r rune) bool {
+	return unicode.IsSpace(r) || unicode.IsPunct(r) || unicode.IsSymbol(r)
+}
+
+// isASCIILike reports whether a rune is an ASCII letter/digit or its full-width
+// equivalent, so DB and ＤＢ scan as a single candidate run.
+func isASCIILike(r rune) bool {
+	f := foldWidth(r)
+	return (f >= 'a' && f <= 'z') || (f >= 'A' && f <= 'Z') || (f >= '0' && f <= '9')
+}
+
+// isJapaneseTermRune reports whether a rune may be part of a Japanese term
+// candidate. Kanji and katakana (with the prolonged-sound mark) form noun and
+// proper-noun cores; hiragana is excluded because runs of hiragana are usually
+// grammatical (particles, verb/adjective inflection) rather than terms.
+func isJapaneseTermRune(r rune) bool {
+	if unicode.Is(unicode.Han, r) || unicode.Is(unicode.Katakana, r) {
+		return true
+	}
+	return r == 'ー' // U+30FC prolonged sound mark, common inside katakana words
+}

--- a/internal/term/term.go
+++ b/internal/term/term.go
@@ -1,0 +1,80 @@
+// Package term extracts a learning corpus's notation preferences — which
+// surface form an author actually uses for a recurring term (DB vs データベース,
+// HTTP vs http) — without any LLM, network access, or external dictionary.
+//
+// The extraction is deterministic and reproducible: the same corpus always
+// yields the same groups, preferred surfaces, and counts. It deliberately does
+// not attempt open-ended synonym discovery. Only two things merge surfaces:
+//
+//   - normalization (normalized_key): case, full-width/half-width ASCII, and
+//     surrounding punctuation differences are folded away deterministically, so
+//     DB / db / ＤＢ share one normalized_key.
+//   - alias bridges (group_key): two different normalized_keys are treated as the
+//     same concept ONLY when the corpus itself spells out the bridge, e.g.
+//     "データベース（DB）" or "データベース。以下、DB". A bare "A（B）" is never
+//     enough; see aliasbridge.go for the conservative rules.
+//
+// normalized_key and group_key are kept as separate responsibilities so a
+// consumer can always tell whether two surfaces were merged by plain
+// normalization or by a corpus-declared alias bridge.
+package term
+
+// Variant is one distinct surface form of a term, scoped to a single profile
+// (one profile == one SQLite database). Two surfaces that fold to the same
+// normalized_key (DB and ＤＢ) are still two variants; they share NormalizedKey
+// and GroupKey but keep their own Surface and counts.
+type Variant struct {
+	// Surface is the exact text as it appeared in the corpus.
+	Surface string
+	// NormalizedKey is the deterministic normalization of Surface (case,
+	// full-width ASCII, and surrounding punctuation folded). It is the unit of
+	// "these are the same spelling".
+	NormalizedKey string
+	// GroupKey is the identifier of the same-concept group this variant belongs
+	// to. It equals "term:"+NormalizedKey for a surface that was never alias
+	// bridged; it differs only when a corpus-declared bridge merged it with
+	// another normalized_key.
+	GroupKey string
+	// Count is how many times Surface occurred across the corpus.
+	Count int
+	// DocCount is how many documents contained Surface at least once.
+	DocCount int
+}
+
+// Group is a same-concept cluster of variants within one profile. Its members
+// share a GroupKey. A group whose variants all share a single normalized_key was
+// formed by normalization alone; a group spanning several normalized_keys was
+// formed by at least one alias bridge.
+type Group struct {
+	GroupKey         string
+	PreferredSurface string
+	TotalCount       int
+	DocCount         int
+	Variants         []Variant
+}
+
+// Profile is a profile-local set of term preferences. It is stored alongside the
+// style distribution in the same per-author SQLite database, never shared
+// between authors, so profile A can prefer "DB" while profile B prefers
+// "データベース".
+type Profile struct {
+	Groups []Group
+}
+
+// Occurrence is a position of a non-preferred surface inside a draft. The check
+// path does not populate it yet; the field exists so a future version can add
+// line/column information to a warning without changing the JSON shape.
+type Occurrence struct {
+	Line   int `json:"line"`
+	Column int `json:"column"`
+}
+
+// Warning reports that a draft used a surface other than the group's preferred
+// one. Occurrences is optional and omitted while only counts are tracked.
+type Warning struct {
+	GroupKey         string       `json:"group_key"`
+	PreferredSurface string       `json:"preferred_surface"`
+	UsedSurface      string       `json:"used_surface"`
+	Count            int          `json:"count"`
+	Occurrences      []Occurrence `json:"occurrences,omitempty"`
+}

--- a/internal/term/term_test.go
+++ b/internal/term/term_test.go
@@ -1,0 +1,358 @@
+package term
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// findGroup returns the group a surface belongs to, by matching any variant's
+// surface, or nil when the surface is absent.
+func findGroup(p Profile, surface string) *Group {
+	for i := range p.Groups {
+		for _, v := range p.Groups[i].Variants {
+			if v.Surface == surface {
+				return &p.Groups[i]
+			}
+		}
+	}
+	return nil
+}
+
+// TestNormalizeKeyFoldsCaseAndWidth pins the normalized_key contract: case,
+// full-width ASCII, and surrounding punctuation fold away, so DB / db / ＤＢ share
+// one key, while Japanese text is left intact.
+func TestNormalizeKeyFoldsCaseAndWidth(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		surface string
+		want    string
+	}{
+		{"DB", "db"},
+		{"db", "db"},
+		{"ＤＢ", "db"},   // full-width letters fold to ASCII
+		{"(DB)", "db"}, // surrounding punctuation is trimmed
+		{"API,", "api"},
+		{"HTTP", "http"},
+		{"データベース", "データベース"}, // Japanese is not folded
+	}
+	for _, c := range cases {
+		if got := normalizeKey(c.surface); got != c.want {
+			t.Errorf("normalizeKey(%q) = %q, want %q", c.surface, got, c.want)
+		}
+	}
+}
+
+// TestNormalizationGroupsSameKey checks that DB, db, and ＤＢ collapse to a single
+// normalized_key and a single group, with three distinct surfaces, when no alias
+// bridge is involved.
+func TestNormalizationGroupsSameKey(t *testing.T) {
+	t.Parallel()
+
+	p := ExtractDocuments([]string{"DB db ＤＢ を使う。"})
+	g := findGroup(p, "DB")
+	if g == nil {
+		t.Fatal("expected a group containing DB")
+	}
+	if g.GroupKey != "term:db" {
+		t.Fatalf("group_key = %q, want term:db", g.GroupKey)
+	}
+	for _, v := range g.Variants {
+		if v.NormalizedKey != "db" {
+			t.Errorf("surface %q has normalized_key %q, want db", v.Surface, v.NormalizedKey)
+		}
+	}
+	if len(g.Variants) != 3 {
+		t.Fatalf("expected 3 surface variants (DB, db, ＤＢ), got %d", len(g.Variants))
+	}
+}
+
+// TestNormalizedKeyAndGroupKeySeparation pins the responsibility split: a group
+// formed by normalization alone has every variant sharing one normalized_key
+// equal to the group_key suffix; a group formed by an alias bridge spans more
+// than one normalized_key, which is how a reader tells the two apart.
+func TestNormalizedKeyAndGroupKeySeparation(t *testing.T) {
+	t.Parallel()
+
+	// Normalization-only group: DB and db.
+	norm := ExtractDocuments([]string{"DB db を使う。"})
+	g := findGroup(norm, "DB")
+	keys := distinctNormalizedKeys(g)
+	if len(keys) != 1 {
+		t.Fatalf("normalization-only group should have one normalized_key, got %v", keys)
+	}
+	if g.GroupKey != "term:"+keys[0] {
+		t.Fatalf("group_key %q should equal term:%s for a normalization-only group", g.GroupKey, keys[0])
+	}
+
+	// Alias-bridged group: データベース（DB）.
+	bridged := ExtractDocuments([]string{"データベース（DB）を使う。データベースは便利。DBも便利。"})
+	bg := findGroup(bridged, "DB")
+	if bg == nil {
+		t.Fatal("expected a bridged group containing DB")
+	}
+	if len(distinctNormalizedKeys(bg)) < 2 {
+		t.Fatalf("alias-bridged group should span >1 normalized_key, got %v", distinctNormalizedKeys(bg))
+	}
+}
+
+func distinctNormalizedKeys(g *Group) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	for _, v := range g.Variants {
+		if _, ok := seen[v.NormalizedKey]; !ok {
+			seen[v.NormalizedKey] = struct{}{}
+			out = append(out, v.NormalizedKey)
+		}
+	}
+	return out
+}
+
+// TestAliasBridgeMergesGroup checks the core bridge: when the corpus declares
+// "データベース（DB）", データベース and DB end up in the same group.
+func TestAliasBridgeMergesGroup(t *testing.T) {
+	t.Parallel()
+
+	patterns := []string{
+		"データベース（DB）を採用する。データベースは速い。DBも速い。",
+		"DB（データベース）を採用する。データベースは速い。DBも速い。",
+		"データベース（以下 DB）を採用する。データベースは速い。DBも速い。",
+		"データベース。以下、DB。データベースは速い。DBも速い。",
+	}
+	for _, doc := range patterns {
+		p := ExtractDocuments([]string{doc})
+		gJa := findGroup(p, "データベース")
+		gEn := findGroup(p, "DB")
+		if gJa == nil || gEn == nil {
+			t.Fatalf("%q: expected both データベース and DB as candidates", doc)
+		}
+		if gJa.GroupKey != gEn.GroupKey {
+			t.Errorf("%q: データベース (%s) and DB (%s) should share a group_key", doc, gJa.GroupKey, gEn.GroupKey)
+		}
+	}
+}
+
+// TestConservativeAliasDetectionRejectsArbitraryParens checks that a bare "A（B）"
+// is never treated as an alias when neither side is a Japanese-phrase ↔ acronym
+// pair.
+func TestConservativeAliasDetectionRejectsArbitraryParens(t *testing.T) {
+	t.Parallel()
+
+	// 関数 (2 kanji, too short to be the long side) and function (lowercase, not an
+	// acronym): must not merge.
+	p := ExtractDocuments([]string{"関数（function）を定義する。関数は便利。functionも便利。"})
+	gJa := findGroup(p, "関数")
+	gEn := findGroup(p, "function")
+	if gJa == nil || gEn == nil {
+		t.Fatal("expected both 関数 and function as candidates")
+	}
+	if gJa.GroupKey == gEn.GroupKey {
+		t.Errorf("関数 and function must not be alias-merged (no acronym bridge), both = %s", gJa.GroupKey)
+	}
+}
+
+// TestIfukaFormBridges checks the "以下、X" abbreviation declaration links the
+// long phrase and the acronym.
+func TestIfukaFormBridges(t *testing.T) {
+	t.Parallel()
+
+	p := ExtractDocuments([]string{"継続的インテグレーション。以下、CI。継続的インテグレーションは重要。CIは重要。"})
+	gJa := findGroup(p, "継続的インテグレーション")
+	gEn := findGroup(p, "CI")
+	if gJa == nil || gEn == nil {
+		t.Fatal("expected both 継続的インテグレーション and CI as candidates")
+	}
+	if gJa.GroupKey != gEn.GroupKey {
+		t.Errorf("「以下、CI」should bridge 継続的インテグレーション and CI: %s vs %s", gJa.GroupKey, gEn.GroupKey)
+	}
+}
+
+// TestNoFalseMergeWithoutBridge checks that two genuine synonyms stay in separate
+// groups when the corpus never declares a bridge between them.
+func TestNoFalseMergeWithoutBridge(t *testing.T) {
+	t.Parallel()
+
+	p := ExtractDocuments([]string{"優先度を上げる。プライオリティを上げる。優先度は重要。プライオリティは重要。"})
+	gA := findGroup(p, "優先度")
+	gB := findGroup(p, "プライオリティ")
+	if gA == nil || gB == nil {
+		t.Fatal("expected both 優先度 and プライオリティ as candidates")
+	}
+	if gA.GroupKey == gB.GroupKey {
+		t.Errorf("優先度 and プライオリティ must not merge without a bridge, both = %s", gA.GroupKey)
+	}
+}
+
+// TestAmbiguousAcronymDoesNotChain checks that a short acronym glossing several
+// different Japanese phrases (each "X（DB）") does not chain those phrases into
+// one group: an ambiguous acronym is dropped rather than fusing unrelated terms.
+func TestAmbiguousAcronymDoesNotChain(t *testing.T) {
+	t.Parallel()
+
+	p := ExtractDocuments([]string{
+		"データベース（DB）を使う。データベースは速い。DBも速い。" +
+			"ダッシュボード（DB）を見る。ダッシュボードは便利。DBは便利。",
+	})
+	gA := findGroup(p, "データベース")
+	gB := findGroup(p, "ダッシュボード")
+	if gA == nil || gB == nil {
+		t.Fatal("expected both データベース and ダッシュボード as candidates")
+	}
+	if gA.GroupKey == gB.GroupKey {
+		t.Errorf("an ambiguous acronym (DB→two phrases) must not chain データベース and ダッシュボード, both = %s", gA.GroupKey)
+	}
+}
+
+// TestUnambiguousAcronymStillBridges guards against over-correction: the same
+// phrase↔acronym pair repeated across documents must still bridge.
+func TestUnambiguousAcronymStillBridges(t *testing.T) {
+	t.Parallel()
+
+	p := ExtractDocuments([]string{
+		"データベース（DB）を使う。DBは速い。",
+		"データベースを設計する。DBを設計する。",
+	})
+	gJa := findGroup(p, "データベース")
+	gEn := findGroup(p, "DB")
+	if gJa == nil || gEn == nil || gJa.GroupKey != gEn.GroupKey {
+		t.Fatalf("a repeated unambiguous pair should still bridge: %v / %v", gJa, gEn)
+	}
+}
+
+// TestPreferredSurfaceSelectionOrder pins the fixed selection order:
+// doc_count, then count, then ascending surface as a stable tie-break.
+func TestPreferredSurfaceSelectionOrder(t *testing.T) {
+	t.Parallel()
+
+	t.Run("doc_count wins over count", func(t *testing.T) {
+		t.Parallel()
+		// DB: 2 docs, count 2. db: 1 doc, count 5. Higher doc_count wins.
+		p := ExtractDocuments([]string{"DB", "DB", "db db db db db"})
+		if got := findGroup(p, "DB").PreferredSurface; got != "DB" {
+			t.Fatalf("preferred = %q, want DB (higher doc_count beats higher count)", got)
+		}
+	})
+
+	t.Run("count wins when doc_count ties", func(t *testing.T) {
+		t.Parallel()
+		// Both in 2 docs; db occurs more often.
+		p := ExtractDocuments([]string{"DB db db", "DB db db"})
+		if got := findGroup(p, "DB").PreferredSurface; got != "db" {
+			t.Fatalf("preferred = %q, want db (higher count on equal doc_count)", got)
+		}
+	})
+
+	t.Run("surface ascending breaks a full tie", func(t *testing.T) {
+		t.Parallel()
+		// Both in 2 docs with equal counts; ASCII 'D' < 'd' so DB wins.
+		p := ExtractDocuments([]string{"DB db", "DB db"})
+		if got := findGroup(p, "DB").PreferredSurface; got != "DB" {
+			t.Fatalf("preferred = %q, want DB (ascending surface tie-break)", got)
+		}
+	})
+}
+
+// TestProfileLocality checks that two different corpora yield different preferred
+// surfaces for the same concept: term data is profile-local, so profile A can
+// prefer DB while profile B prefers db.
+func TestProfileLocality(t *testing.T) {
+	t.Parallel()
+
+	profileA := ExtractDocuments([]string{"DB を使う。", "DB を使う。", "db"})
+	profileB := ExtractDocuments([]string{"db を使う。", "db を使う。", "DB"})
+
+	if got := findGroup(profileA, "DB").PreferredSurface; got != "DB" {
+		t.Fatalf("profile A preferred = %q, want DB", got)
+	}
+	if got := findGroup(profileB, "db").PreferredSurface; got != "db" {
+		t.Fatalf("profile B preferred = %q, want db", got)
+	}
+}
+
+// TestCheckTextFlagsNonPreferredSurface checks that a draft using a non-preferred
+// surface (including a full-width or bridged form) produces a warning, and a
+// draft using the preferred surface does not.
+func TestCheckTextFlagsNonPreferredSurface(t *testing.T) {
+	t.Parallel()
+
+	// Profile prefers DB; AI is bridged to 人工知能 (人工知能 wins on counts).
+	p := ExtractDocuments([]string{
+		"DB を使う。DB は速い。",
+		"人工知能（AI）を使う。人工知能は賢い。人工知能はすごい。",
+	})
+
+	warnings := p.CheckText("ＤＢ に保存し、AI で処理する。")
+	if len(warnings) == 0 {
+		t.Fatal("expected warnings for non-preferred surfaces ＤＢ and AI")
+	}
+	gotBySurface := map[string]Warning{}
+	for _, w := range warnings {
+		gotBySurface[w.UsedSurface] = w
+	}
+	if w, ok := gotBySurface["ＤＢ"]; !ok || w.PreferredSurface != "DB" {
+		t.Errorf("expected ＤＢ flagged with preferred DB, got %+v", w)
+	}
+	if w, ok := gotBySurface["AI"]; !ok || w.PreferredSurface != "人工知能" {
+		t.Errorf("expected AI flagged with preferred 人工知能, got %+v", w)
+	}
+
+	// Using the preferred surface produces no warning for that group.
+	for _, w := range p.CheckText("DB に保存する。") {
+		if w.UsedSurface == "DB" {
+			t.Errorf("DB is the preferred surface and must not be flagged: %+v", w)
+		}
+	}
+}
+
+// TestWarningOccurrencesShape locks the forward-compatible JSON shape: with no
+// occurrences the field is omitted entirely; adding occurrences later surfaces a
+// line/column array without changing any existing field.
+func TestWarningOccurrencesShape(t *testing.T) {
+	t.Parallel()
+
+	without, err := json.Marshal(Warning{GroupKey: "term:db", PreferredSurface: "DB", UsedSurface: "db", Count: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(without), "occurrences") {
+		t.Fatalf("occurrences must be omitted when empty, got %s", without)
+	}
+
+	with, err := json.Marshal(Warning{
+		GroupKey: "term:db", PreferredSurface: "DB", UsedSurface: "db", Count: 1,
+		Occurrences: []Occurrence{{Line: 3, Column: 12}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{`"occurrences"`, `"line":3`, `"column":12`} {
+		if !strings.Contains(string(with), want) {
+			t.Fatalf("expected %s in %s", want, with)
+		}
+	}
+}
+
+// TestDeterministic checks that extraction is reproducible: the same documents
+// always yield the same groups, keys, preferred surfaces, and counts.
+func TestDeterministic(t *testing.T) {
+	t.Parallel()
+
+	docs := []string{
+		"データベース（DB）を使う。DBは速い。継続的インテグレーション。以下、CI。CIは重要。",
+		"DB と CI を組み合わせる。データベースは便利。",
+	}
+	first, err := json.Marshal(ExtractDocuments(docs))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for range 5 {
+		again, err := json.Marshal(ExtractDocuments(docs))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(first) != string(again) {
+			t.Fatalf("extraction is not deterministic:\n%s\nvs\n%s", first, again)
+		}
+	}
+}

--- a/internal/term/unionfind.go
+++ b/internal/term/unionfind.go
@@ -1,0 +1,46 @@
+package term
+
+// unionFind is a tiny disjoint-set over normalized_keys, used to merge keys that
+// a corpus-declared alias bridge linked. It is deterministic: find always
+// resolves to a stable root for a given set of unions, and group_key assignment
+// then picks the smallest key in each component rather than the root itself, so
+// the externally visible id never depends on union order.
+type unionFind struct {
+	parent map[string]string
+}
+
+func newUnionFind() *unionFind {
+	return &unionFind{parent: make(map[string]string)}
+}
+
+func (u *unionFind) add(key string) {
+	if _, ok := u.parent[key]; !ok {
+		u.parent[key] = key
+	}
+}
+
+func (u *unionFind) find(key string) string {
+	root := key
+	for u.parent[root] != root {
+		root = u.parent[root]
+	}
+	// Path compression keeps repeated lookups cheap without affecting the result.
+	for u.parent[key] != root {
+		u.parent[key], key = root, u.parent[key]
+	}
+	return root
+}
+
+// union merges the two keys' components. The smaller key (lexicographically) is
+// made the root so the structure is deterministic regardless of call order.
+func (u *unionFind) union(a, b string) {
+	ra, rb := u.find(a), u.find(b)
+	if ra == rb {
+		return
+	}
+	if ra < rb {
+		u.parent[rb] = ra
+	} else {
+		u.parent[ra] = rb
+	}
+}


### PR DESCRIPTION
## What

omokage now learns each profile's **notation preferences** — which surface form an author actually uses for a recurring term (`DB` vs `データベース`, `HTTP` vs `http`) — and can flag a draft that strays from them. It runs entirely locally: **no LLM, no network, no external dictionary**, the original training text is never stored (only surfaces and counts), and extraction is fully deterministic.

## How it works

Two responsibilities are kept separate:

- **`normalized_key`** — deterministic fold of letter case, full-width/half-width ASCII, and surrounding punctuation, so `DB` / `db` / `ＤＢ` share one key.
- **`group_key`** — same-concept group id. Different normalized keys merge **only when the corpus itself declares the bridge** (`データベース（DB）`, `DB（データベース）`, `データベース（以下 DB）`, `データベース。以下、DB`). Bridges are conservative: one side must be a Japanese phrase, the other a short uppercase acronym; a bare `A（B）` never merges, and a shared acronym glossing several different phrases is **dropped** rather than chaining unrelated terms. So `優先度` and `プライオリティ` stay separate unless explicitly bridged.

Because the two keys are stored separately, a normalization merge (one `normalized_key`) is always distinguishable from an alias-bridge merge (several under one `group_key`).

**Preferred surface** is chosen in a fixed, stable order: highest `doc_count`, then highest `count`, then the lexicographically smallest surface.

## Surfaces

- `train` extracts and saves term preferences (profile-local) into the same SQLite db, in new `term_group`/`term_variant` tables (auto-created for profiles trained before this change).
- `show --format json` gains a `term_preferences` array (`group_key`, `preferred_surface`, `doc_count`, `total_count`, `variants[]`).
- `check --format json` gains a `term_warnings` array (`group_key`, `preferred_surface`, `used_surface`, `count`). It is a **separate layer that never affects the similarity score**. `occurrences` (line/column) is a reserved optional field for the future.
- Plain `check` output, its speed, and the existing similarity scoring are unchanged.

## Tests

- `internal/term`: normalization, normalized_key/group_key separation, alias bridge (all four declared forms), conservative detection (arbitrary `A（B）` rejected, `以下、X` bridges), no-false-merge, ambiguous-acronym-does-not-chain, preferred-surface order (doc_count → count → tie-break), profile locality, check warnings, forward-compatible occurrences shape, determinism.
- `internal/storage`: SaveTerms/LoadTerms round-trip, replace-on-resave, missing file, and loading a terms-less (migrated) profile.
- `cmd`: end-to-end train → `show --format json` → `check --format json`, plus shape stability.

Verified with `go test ./...`, `go vet ./...`, `gofmt`, `golangci-lint` (new files clean), `-race`, and a manual run over a 221-file real corpus.

## Out of scope

Term penalties in the similarity score, full terminology control, dictionary/LLM synonym discovery, half-width katakana folding, and storing full text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Term preference learning: The app now learns and tracks preferred surface forms for recurring terms (e.g., "DB" vs "データベース") from training data, including support for alias bridging.
  * Enhanced JSON output: `show --format json` includes `term_preferences`, and `check --format json` includes `term_warnings` to alert when non-preferred term surfaces are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->