### PR TITLE
docs: cut the 0.4.0 release in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and per-release binaries and notes are published from git tags by GoReleaser.
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-11
+
 ### Changed
 
 - Japanese scoring now uses morphological analysis (kagome) where whitespace


### PR DESCRIPTION
Cuts the 0.4.0 release: moves the `[Unreleased]` entries under `## [0.4.0] - 2026-06-11`.

0.4.0 ships the kagome morphological analysis for Japanese scoring (#10): function words counted as whole morphemes, register read from the closing predicate, conjunction frequency on a real morpheme denominator, two opt-in features off by default, and a feature-version warning on `check`.

Once merged, tag `v0.4.0` to trigger the GoReleaser release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)