### PR TITLE
Improve score calibration and drift handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and per-release binaries and notes are published from git tags by GoReleaser.
 
 ## [Unreleased]
 
+### Added
+
+- Training now records a leave-one-out self-similarity baseline per profile.
+  `check` and `check --explain` show that baseline as a self-similarity anchor,
+  so a user can read a score against the author's own typical range rather than
+  against a fixed global scale.
+
+### Changed
+
+- `check` now maps drift to similarity through the profile's own self-similarity
+  baseline when that data is present, anchoring the median self-similar document
+  near 90 and preserving a visible "own range" in the output. Older profiles
+  still work through the previous fixed-scale path, but warn until retrained.
+- Register drift now saturates instead of adding without bound, so a register flip
+  no longer collapses both "otherwise near match" and "wholly different author"
+  to the same 0% score.
+- Grouped lexical drift now distinguishes "group absent" from "group active with
+  exact match", fixing the case where a perfect function-word match could score
+  slightly worse than a tiny mismatch.
+- The register tolerance was widened slightly after the saturation change so an
+  author's mild register wobble is less likely to be over-penalized.
+- The README examples and scoring explanation now reflect the calibrated score
+  output and the self-similarity anchor.
+
 ## [0.4.0] - 2026-06-11
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ omokage learns how you write from your past writing, then scores how close a new
 
 ## What it does (and doesn't)
 
-- **Does**: compare *style* — sentence shape, register (敬体 / 常体), kanji/kana balance, word and character patterns — between a draft and a trained author, and point out where they differ.
-- **Doesn't**: judge meaning, correctness, originality, or quality. It is not an AI-text detector. A high score means "this reads like the voice you trained," nothing more.
+- Compares style — sentence shape, register (敬体 / 常体), kanji/kana balance, word and character patterns — between a draft and a trained author, and points out where they differ.
+- Does not judge meaning, correctness, originality, or quality. It is not an AI-text detector. A high score means only "this reads like the voice you trained."
 
 It is built for an LLM as much as for a person: an agent can run `check` after each rewrite, read the differences, and revise until the draft sits closer to the voice.
 
@@ -42,7 +42,7 @@ Profile: /home/me/blog/profiles/me.db
 Corpus reliability: good.
 $ omokage check examples/en/draft-keeps-voice.md  # score a draft (one profile needs no --author)
 Author: me
-Similarity: 70%
+Similarity: 92% (this author's self-similarity median 90%, range 75-91%)
 
 Differences:
 - character n-gram "gh" is higher than reference
@@ -57,7 +57,7 @@ The same idea rewritten in a stiff, formal voice scores low:
 ```shell
 $ omokage check --author me examples/en/draft-lost-voice.md
 Author: me
-Similarity: 26%
+Similarity: 0% (this author's self-similarity median 90%, range 75-91%)
 
 Differences:
 - average sentence length is higher than reference
@@ -98,7 +98,7 @@ These checks look at sample size and consistency, not writing quality.
 
 ![doctor demo](./doc/img/doctor.gif)
 
-`doctor --format json` gives the same report as data. `train` prints the reliability too (with the findings and a pointer to `doctor` when a corpus is thin or mixed), and `show --format json` carries the rating and findings so you can read a profile's standing later. A mixed corpus is flagged by the feature it disagrees on (often the register or kanji/kana balance) — the fix is to split it into one profile per voice.
+`doctor --format json` returns the same report as data. `train` prints the reliability too, and `show --format json` stores the rating and findings so you can inspect a profile later. A mixed corpus is usually flagged by the feature it disagrees on, often the register or kanji/kana balance; the fix is to split it into one profile per voice.
 
 ## Choosing the author
 
@@ -121,24 +121,26 @@ These checks look at sample size and consistency, not writing quality.
 $ score=$(omokage check --score-only draft.md)
 $ [ "$score" -ge 70 ] && echo "close enough"
 
-$ omokage check --author me --explain examples/ja/draft-lost-voice.md
+$ omokage check --author me --explain examples/en/draft-lost-voice.md
 Author: me
-Similarity: 0%
+Similarity: 0% (this author's self-similarity median 90%, range 75-91%)
+Score driver: lexical
+Scoring note: This score is computed from the full fingerprint and structure mix; the paragraph-level scalar drift below is supporting detail and usually contributes less than the lexical fingerprint.
 
 High-level style differences (fix these first):
-  1. polite sentence-ending ratio is lower than reference [register]
-       target 0.000  reference 1.000 ± 0.000  (50.0σ)
+  1. average sentence length is higher than reference [structure]
+       target 292.3  reference 40.4 ± 1.540  (62.3σ)
   ...
 
 Paragraphs that drift most:
-  #2 (50.0σ; polite sentence-ending ratio lower): 雨天時は在宅で過ごすケースが多い。特段の活動は行わない…
+  #2 (74.9σ; average sentence length higher): Subsequently, a notebook is utilized for the purpo…
 ```
 
 ![explain demo](./doc/img/explain.gif)
 
 ## Using omokage with an LLM
 
-Train once, then on each rewrite have the agent run `check --format json` and read it back. The JSON leads with `high_level_drift` — the editable features, each with a `priority` and `actionable` flag — so the agent knows what to change first; `segments` points at the paragraphs that drift most, and `term_warnings` flags notation that differs from your learned preference (never part of the score). For a lighter payload to hand an agent, `show --author me --format json --summary` returns provenance and the quality rating without the (often large) term list. omokage tells the agent how close the draft sits to your voice and where it strays — not whether it is correct or good, so keep a human in the loop.
+Train once, then have the agent run `check --format json` after each rewrite. The JSON leads with `high_level_drift`, the editable features, each with a `priority` and `actionable` flag; `segments` points at the paragraphs that drift most, and `term_warnings` flags notation that differs from your learned preference. For a lighter payload, `show --author me --format json --summary` returns provenance and the quality rating without the often large term list. omokage tells the agent how close the draft sits to your voice and where it strays, not whether it is correct or good, so keep a human in the loop.
 
 ## Term preferences
 
@@ -157,7 +159,7 @@ By default omokage finds an `omokage.toml` by walking up from the current direct
 
 ## How it scores
 
-Training measures a set of stylistic features per document and stores their mean and spread in a SQLite database under `profiles/` (one per author) — the numbers only, never the text. The features are register (敬体 / 常体), script balance (kanji/hiragana/katakana), function words, character n-grams, and shape (sentence and paragraph length, punctuation, layout). A check measures the same features on the draft and scores each by how far it strays from your usual range, as a z-score in the spirit of Burrows's Delta: the function-word and n-gram fingerprint carries most of the signal, a clear register shift is penalized on top, and shape only nudges. Code blocks are stripped first, so the score reflects prose.
+Training measures a set of stylistic features per document and stores their mean and spread in a SQLite database under `profiles/`, one per author. It stores only the numbers, never the text. The features are register (敬体 / 常体), script balance (kanji/hiragana/katakana), function words, character n-grams, and shape (sentence and paragraph length, punctuation, layout). A check measures the same features on the draft and scores each by how far it strays from your usual range, as a z-score in the spirit of Burrows's Delta: the function-word and n-gram fingerprint carries most of the signal, a clear register shift is penalized on top, and shape only nudges. The final 0-100 score is calibrated against the profile's leave-one-out self-similarity baseline, so "90%" means "close to this author's own typical variation" rather than "three sigmas from the mean." Profiles trained before this baseline was added still work, but retraining is recommended so the calibrated score and self-similarity anchor are available. Code blocks are stripped first, so the score reflects prose.
 
 For Japanese, which has no spaces between words, these features use morphological analysis (kagome) rather than whitespace tokenization: the function-word fingerprint counts particles and auxiliaries as whole morphemes (not substrings), the register is read from each sentence's closing predicate, and conjunction frequency uses a real morpheme denominator. On a held-out author-attribution test this raised accuracy over the previous heuristics. Two further Japanese signals — a part-of-speech n-gram fingerprint and lemma-based vocabulary richness — are available but off by default (`pos_ngram_frequency`, `type_token_ratio` in the config), since on that test they did not help.
 

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -516,6 +516,7 @@ func (a *App) runCheck(args []string) int {
 		return 1
 	}
 	a.warnFeatureVersion(record)
+	a.warnSelfSimilarityCalibration(record)
 
 	targetPath, err := resolvePath(a.workDir, flagSet.Arg(0))
 	if err != nil {
@@ -529,8 +530,7 @@ func (a *App) runCheck(args []string) int {
 			writeLine(a.stderr, err)
 			return 1
 		}
-		comparison := profile.Score(record.Distribution, targetMetrics, scope.Config.Features)
-		comparison.SelfSimilarity = profile.SelfSimilarityAnchorForStats(record.SelfSimilarity)
+		comparison := profile.ScoreRecord(record, targetMetrics, scope.Config.Features)
 		writef(a.stdout, "%d\n", comparison.Similarity)
 		return 0
 	}
@@ -545,8 +545,7 @@ func (a *App) runCheck(args []string) int {
 			writeLine(a.stderr, err)
 			return 1
 		}
-		comparison := profile.Score(record.Distribution, targetMetrics, scope.Config.Features)
-		comparison.SelfSimilarity = profile.SelfSimilarityAnchorForStats(record.SelfSimilarity)
+		comparison := profile.ScoreRecord(record, targetMetrics, scope.Config.Features)
 		renderComparison(a.stdout, renderOptions{
 			author:     record.Author,
 			comparison: comparison,
@@ -567,8 +566,7 @@ func (a *App) runCheck(args []string) int {
 		writeLine(a.stderr, err)
 		return 1
 	}
-	explanation := profile.Explain(record.Distribution, targetMetrics, segments, scope.Config.Features)
-	explanation.SelfSimilarity = profile.SelfSimilarityAnchorForStats(record.SelfSimilarity)
+	explanation := profile.ExplainRecord(record, targetMetrics, segments, scope.Config.Features)
 	if *format == formatJSON {
 		// Term warnings are a separate layer from the similarity score: they report
 		// where the draft used a non-preferred surface, and never alter the score.
@@ -600,6 +598,14 @@ func (a *App) warnFeatureVersion(record profile.Record) {
 		writef(a.stderr, "warning: profile %q was trained with an older feature set (v%d, this build uses v%d); scores may be off until you retrain it with 'omokage train'.\n",
 			record.Author, record.FeatureVersion, feature.Version)
 	}
+}
+
+func (a *App) warnSelfSimilarityCalibration(record profile.Record) {
+	if record.SelfSimilarity != nil {
+		return
+	}
+	writef(a.stderr, "warning: profile %q has no self-similarity calibration; retrain it with the current omokage to improve score calibration (two or more usable documents are required).\n",
+		record.Author)
 }
 
 func (a *App) runDiff(args []string) int {

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -395,6 +395,7 @@ func (a *App) runTrain(args []string) int {
 		FileCount:      len(files),
 		FeatureVersion: feature.Version,
 		Distribution:   distribution,
+		SelfSimilarity: profile.ComputeSelfSimilarityStats(documentMetrics(docs), scope.Config.Features),
 	}
 	if err := storage.SaveProfile(profilePath, record); err != nil {
 		writeLine(a.stderr, err)
@@ -1384,6 +1385,14 @@ func renderComparison(w io.Writer, opt renderOptions) {
 	for _, difference := range opt.comparison.Differences {
 		writef(w, "- %s\n", difference)
 	}
+}
+
+func documentMetrics(docs []feature.Document) []feature.Metrics {
+	metrics := make([]feature.Metrics, 0, len(docs))
+	for _, doc := range docs {
+		metrics = append(metrics, doc.Metrics)
+	}
+	return metrics
 }
 
 // isTerminal reports whether the writer is an interactive terminal. It is used to

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -530,6 +530,7 @@ func (a *App) runCheck(args []string) int {
 			return 1
 		}
 		comparison := profile.Score(record.Distribution, targetMetrics, scope.Config.Features)
+		comparison.SelfSimilarity = profile.SelfSimilarityAnchorForStats(record.SelfSimilarity)
 		writef(a.stdout, "%d\n", comparison.Similarity)
 		return 0
 	}
@@ -544,9 +545,11 @@ func (a *App) runCheck(args []string) int {
 			writeLine(a.stderr, err)
 			return 1
 		}
+		comparison := profile.Score(record.Distribution, targetMetrics, scope.Config.Features)
+		comparison.SelfSimilarity = profile.SelfSimilarityAnchorForStats(record.SelfSimilarity)
 		renderComparison(a.stdout, renderOptions{
 			author:     record.Author,
-			comparison: profile.Score(record.Distribution, targetMetrics, scope.Config.Features),
+			comparison: comparison,
 		})
 		// A one-line pointer to the detailed report, but only when a person is
 		// watching: it goes to stderr and only when stderr is a terminal. A pipe, a
@@ -565,6 +568,7 @@ func (a *App) runCheck(args []string) int {
 		return 1
 	}
 	explanation := profile.Explain(record.Distribution, targetMetrics, segments, scope.Config.Features)
+	explanation.SelfSimilarity = profile.SelfSimilarityAnchorForStats(record.SelfSimilarity)
 	if *format == formatJSON {
 		// Term warnings are a separate layer from the similarity score: they report
 		// where the draft used a non-preferred surface, and never alter the score.
@@ -1379,12 +1383,21 @@ func renderComparison(w io.Writer, opt renderOptions) {
 		writef(w, "Reference: %s\n", opt.leftPath)
 		writef(w, "Target: %s\n", opt.rightPath)
 	}
-	writef(w, "Similarity: %d%%\n", opt.comparison.Similarity)
+	writeSimilarityLine(w, opt.comparison.Similarity, opt.comparison.SelfSimilarity)
 	writeLine(w)
 	writeLine(w, "Differences:")
 	for _, difference := range opt.comparison.Differences {
 		writef(w, "- %s\n", difference)
 	}
+}
+
+func writeSimilarityLine(w io.Writer, similarity int, anchor *profile.SimilarityAnchor) {
+	writef(w, "Similarity: %d%%", similarity)
+	if anchor != nil {
+		writef(w, " (this author's self-similarity median %d%%, range %d-%d%%)",
+			anchor.Median, anchor.Low, anchor.High)
+	}
+	writeLine(w)
 }
 
 func documentMetrics(docs []feature.Document) []feature.Metrics {

--- a/cmd/app_test.go
+++ b/cmd/app_test.go
@@ -225,6 +225,32 @@ func TestTrainStoresSelfSimilarityStats(t *testing.T) {
 	}
 }
 
+func TestCheckWarnsWhenCalibrationMissing(t *testing.T) {
+	t.Parallel()
+
+	workDir := trainedProject(t)
+	profilePath := filepath.Join(workDir, "profiles", "me.db")
+	record, err := storage.LoadProfile(profilePath)
+	if err != nil {
+		t.Fatalf("load profile: %v", err)
+	}
+	record.SelfSimilarity = nil
+	if err := storage.SaveProfile(profilePath, record); err != nil {
+		t.Fatalf("save profile without calibration: %v", err)
+	}
+
+	writeTestFile(t, filepath.Join(workDir, "draft.txt"),
+		"今日はとても良い天気です。散歩に出かけました。気持ちが良かったです。")
+
+	code, _, stderr := runApp(t, workDir, "check", "--author", "me", "draft.txt")
+	if code != 0 {
+		t.Fatalf("check failed: %s", stderr)
+	}
+	if !strings.Contains(stderr, "no self-similarity calibration") {
+		t.Fatalf("expected missing-calibration warning, got stderr=%q", stderr)
+	}
+}
+
 func TestCheckPlainOutputStaysClean(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/app_test.go
+++ b/cmd/app_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/nao1215/omokage/internal/storage"
 )
 
 func TestAppLifecycle(t *testing.T) {
@@ -113,7 +115,7 @@ func TestCheckExplainTextOutput(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("check --explain failed: stderr=%q", stderr)
 	}
-	for _, want := range []string{"Author: me", "Similarity:", "High-level style", "σ)"} {
+	for _, want := range []string{"Author: me", "Similarity:", "Score driver:", "Scoring note:", "High-level style", "σ)"} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("explain output missing %q:\n%s", want, stdout)
 		}
@@ -135,6 +137,8 @@ func TestCheckJSONOutput(t *testing.T) {
 	var payload struct {
 		Author     string `json:"author"`
 		Similarity int    `json:"similarity"`
+		Driver     string `json:"score_driver"`
+		Note       string `json:"score_note"`
 		HighLevel  []struct {
 			Feature       string  `json:"feature"`
 			Category      string  `json:"category"`
@@ -163,6 +167,12 @@ func TestCheckJSONOutput(t *testing.T) {
 	if payload.Similarity < 0 || payload.Similarity > 100 {
 		t.Fatalf("similarity out of range: %d", payload.Similarity)
 	}
+	if payload.Driver == "" {
+		t.Fatal("expected score_driver in JSON output")
+	}
+	if payload.Note == "" {
+		t.Fatal("expected score_note in JSON output")
+	}
 	if len(payload.HighLevel) == 0 {
 		t.Fatal("expected high-level drift entries in JSON output")
 	}
@@ -181,6 +191,25 @@ func TestCheckJSONOutput(t *testing.T) {
 	}
 	if payload.Segments[0].Feature != "polite sentence-ending ratio" {
 		t.Fatalf("expected register drift to lead the localization, got %q", payload.Segments[0].Feature)
+	}
+}
+
+func TestTrainStoresSelfSimilarityStats(t *testing.T) {
+	t.Parallel()
+
+	workDir := trainedProject(t)
+	record, err := storage.LoadProfile(filepath.Join(workDir, "profiles", "me.db"))
+	if err != nil {
+		t.Fatalf("load profile: %v", err)
+	}
+	if record.SelfSimilarity == nil {
+		t.Fatal("expected self-similarity stats to be stored at train time")
+	}
+	if len(record.SelfSimilarity.MeanZ) != 3 {
+		t.Fatalf("expected 3 leave-one-out samples, got %d", len(record.SelfSimilarity.MeanZ))
+	}
+	if record.SelfSimilarity.MeanZMedian <= 0 {
+		t.Fatalf("expected a positive leave-one-out median, got %f", record.SelfSimilarity.MeanZMedian)
 	}
 }
 

--- a/cmd/app_test.go
+++ b/cmd/app_test.go
@@ -115,7 +115,7 @@ func TestCheckExplainTextOutput(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("check --explain failed: stderr=%q", stderr)
 	}
-	for _, want := range []string{"Author: me", "Similarity:", "Score driver:", "Scoring note:", "High-level style", "σ)"} {
+	for _, want := range []string{"Author: me", "Similarity:", "self-similarity median", "Score driver:", "Scoring note:", "High-level style", "σ)"} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("explain output missing %q:\n%s", want, stdout)
 		}
@@ -137,6 +137,12 @@ func TestCheckJSONOutput(t *testing.T) {
 	var payload struct {
 		Author     string `json:"author"`
 		Similarity int    `json:"similarity"`
+		Anchor     *struct {
+			Median  int `json:"median"`
+			Low     int `json:"low"`
+			High    int `json:"high"`
+			Samples int `json:"samples"`
+		} `json:"self_similarity_anchor"`
 		Driver     string `json:"score_driver"`
 		Note       string `json:"score_note"`
 		HighLevel  []struct {
@@ -166,6 +172,12 @@ func TestCheckJSONOutput(t *testing.T) {
 	}
 	if payload.Similarity < 0 || payload.Similarity > 100 {
 		t.Fatalf("similarity out of range: %d", payload.Similarity)
+	}
+	if payload.Anchor == nil {
+		t.Fatal("expected self_similarity_anchor in JSON output")
+	}
+	if payload.Anchor.Median <= 0 || payload.Anchor.Samples != 3 {
+		t.Fatalf("unexpected self_similarity_anchor: %+v", payload.Anchor)
 	}
 	if payload.Driver == "" {
 		t.Fatal("expected score_driver in JSON output")
@@ -226,6 +238,9 @@ func TestCheckPlainOutputStaysClean(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "Similarity:") {
 		t.Fatalf("plain check stdout missing the score: %q", stdout)
+	}
+	if !strings.Contains(stdout, "self-similarity median") {
+		t.Fatalf("plain check stdout should include the self-similarity anchor: %q", stdout)
 	}
 	// The output is captured (not a terminal), so the discoverability tip must be
 	// suppressed on both streams: a pipe, a redirect, a $(...) capture, or an LLM

--- a/cmd/explain.go
+++ b/cmd/explain.go
@@ -19,7 +19,7 @@ func renderExplanationText(w io.Writer, author string, explanation profile.Expla
 	if author != "" {
 		writef(w, "Author: %s\n", author)
 	}
-	writef(w, "Similarity: %d%%\n", explanation.Similarity)
+	writeSimilarityLine(w, explanation.Similarity, explanation.SelfSimilarity)
 	if explanation.ScoreDriver != "" {
 		writef(w, "Score driver: %s\n", explanation.ScoreDriver)
 	}
@@ -78,6 +78,7 @@ func renderExplanationJSON(w io.Writer, author string, explanation profile.Expla
 	payload := explanationJSON{
 		Author:         author,
 		Similarity:     explanation.Similarity,
+		SelfSimilarity: toAnchorJSON(explanation.SelfSimilarity),
 		ScoreDriver:    explanation.ScoreDriver,
 		ScoreNote:      explanation.ScoreNote,
 		HighLevelDrift: toDriftJSON(high),
@@ -93,6 +94,7 @@ func renderExplanationJSON(w io.Writer, author string, explanation profile.Expla
 type explanationJSON struct {
 	Author         string             `json:"author"`
 	Similarity     int                `json:"similarity"`
+	SelfSimilarity *similarityAnchorJSON `json:"self_similarity_anchor,omitempty"`
 	ScoreDriver    string             `json:"score_driver,omitempty"`
 	ScoreNote      string             `json:"score_note,omitempty"`
 	HighLevelDrift []featureDriftJSON `json:"high_level_drift"`
@@ -161,6 +163,13 @@ type segmentJSON struct {
 	Direction string  `json:"direction"`
 }
 
+type similarityAnchorJSON struct {
+	Median  int `json:"median"`
+	Low     int `json:"low"`
+	High    int `json:"high"`
+	Samples int `json:"samples"`
+}
+
 // splitDrifts separates the prioritized drift list into its high-level and
 // low-level halves while preserving the priority order within each.
 func splitDrifts(drifts []profile.FeatureDrift) (high, low []profile.FeatureDrift) {
@@ -218,6 +227,18 @@ func toSegmentJSON(segments []profile.SegmentDrift) []segmentJSON {
 		})
 	}
 	return out
+}
+
+func toAnchorJSON(anchor *profile.SimilarityAnchor) *similarityAnchorJSON {
+	if anchor == nil {
+		return nil
+	}
+	return &similarityAnchorJSON{
+		Median:  anchor.Median,
+		Low:     anchor.Low,
+		High:    anchor.High,
+		Samples: anchor.Samples,
+	}
 }
 
 // formatValue trims feature values to a readable width: ratios sit in [0,1] and

--- a/cmd/explain.go
+++ b/cmd/explain.go
@@ -20,6 +20,12 @@ func renderExplanationText(w io.Writer, author string, explanation profile.Expla
 		writef(w, "Author: %s\n", author)
 	}
 	writef(w, "Similarity: %d%%\n", explanation.Similarity)
+	if explanation.ScoreDriver != "" {
+		writef(w, "Score driver: %s\n", explanation.ScoreDriver)
+	}
+	if explanation.ScoreNote != "" {
+		writef(w, "Scoring note: %s\n", explanation.ScoreNote)
+	}
 
 	high, low := splitDrifts(explanation.Drifts)
 
@@ -72,6 +78,8 @@ func renderExplanationJSON(w io.Writer, author string, explanation profile.Expla
 	payload := explanationJSON{
 		Author:         author,
 		Similarity:     explanation.Similarity,
+		ScoreDriver:    explanation.ScoreDriver,
+		ScoreNote:      explanation.ScoreNote,
 		HighLevelDrift: toDriftJSON(high),
 		LowLevelDrift:  toDriftJSON(low),
 		Segments:       toSegmentJSON(explanation.Segments),
@@ -85,6 +93,8 @@ func renderExplanationJSON(w io.Writer, author string, explanation profile.Expla
 type explanationJSON struct {
 	Author         string             `json:"author"`
 	Similarity     int                `json:"similarity"`
+	ScoreDriver    string             `json:"score_driver,omitempty"`
+	ScoreNote      string             `json:"score_note,omitempty"`
 	HighLevelDrift []featureDriftJSON `json:"high_level_drift"`
 	LowLevelDrift  []featureDriftJSON `json:"low_level_drift"`
 	Segments       []segmentJSON      `json:"segments"`

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -391,8 +391,9 @@ func featureDrifts(reference feature.Distribution, target feature.Metrics, flags
 // similarityFromDrifts reduces per-feature drifts to the same similarity Score
 // has always produced: each group's mean z is fed to combineDrift, which keeps
 // the lexical fingerprint leading, charges register only for its excess, and lets
-// the structural remainder nudge. Reconstructing the group means from the drift
-// list keeps a single source of truth instead of duplicating the accumulation.
+// the structural remainder nudge. Presence is tracked by active feature count,
+// not by value>0, so an exact-match sub-signal (z=0) still participates in the
+// lexical mean instead of being misread as absent.
 func similarityFromDrifts(drifts []FeatureDrift) int {
 	return similarityFromBreakdown(summarizeDrifts(drifts))
 }
@@ -450,7 +451,7 @@ func summarizeDrifts(drifts []FeatureDrift) driftBreakdown {
 	breakdown.lexicalTerm = lexicalGroupMean(groups, breakdown.counts)
 	breakdown.registerTerm = registerWeight * registerPenalty(groups.register)
 	breakdown.otherTerm = otherStructWeight * groups.other
-	breakdown.meanZ = combineDrift(groups)
+	breakdown.meanZ = combineDriftWithCounts(groups, breakdown.counts)
 	return breakdown
 }
 
@@ -791,12 +792,18 @@ func Compare(reference feature.Metrics, target feature.Metrics, flags config.Fea
 	// Combine the groups the same way Score does so the diff stays consistent with
 	// check: averaging within each group first keeps the many character n-grams
 	// from drowning out a register difference between the two documents.
-	drift := combineCompareDrift(groupDrift{
+	counts := groupCounts{
+		register:     registerCount,
+		other:        otherCount,
+		functionWord: functionWordCount,
+		ngram:        ngramCount,
+	}
+	drift := combineCompareDriftWithCounts(groupDrift{
 		register:     meanOf(registerDist, registerCount),
 		other:        meanOf(otherDist, otherCount),
 		functionWord: meanOf(functionWordDist, functionWordCount),
 		ngram:        meanOf(ngramDist, ngramCount),
-	})
+	}, counts)
 	similarity := clampPercent(int(math.Round((1 - drift) * 100)))
 
 	sort.SliceStable(results, func(i int, j int) bool {
@@ -894,10 +901,14 @@ const explanationScoreNote = "This score is computed from the full fingerprint a
 // resolution between a near-match with the wrong register and a wholly different
 // author. The noisy structural remainder only nudges the result.
 func combineDrift(g groupDrift) float64 {
-	lexical := lexicalGroupMean(g, groupCounts{
+	return combineDriftWithCounts(g, groupCounts{
 		functionWord: boolCount(g.functionWord != 0),
 		ngram:        boolCount(g.ngram != 0),
 	})
+}
+
+func combineDriftWithCounts(g groupDrift, counts groupCounts) float64 {
+	lexical := lexicalGroupMean(g, counts)
 	return lexical + registerWeight*registerPenalty(g.register) + otherStructWeight*g.other
 }
 
@@ -920,25 +931,32 @@ const (
 // n-gram distances), a register difference is added with a fixed weight, and the
 // remaining structural features contribute a moderate share.
 func combineCompareDrift(g groupDrift) float64 {
-	lexical := lexicalGroupMean(g, groupCounts{
+	return combineCompareDriftWithCounts(g, groupCounts{
 		functionWord: boolCount(g.functionWord != 0),
 		ngram:        boolCount(g.ngram != 0),
 	})
+}
+
+func combineCompareDriftWithCounts(g groupDrift, counts groupCounts) float64 {
+	lexical := lexicalGroupMean(g, counts)
 	return lexical + registerCompareWeight*g.register + otherCompareWeight*g.other
 }
 
 func lexicalGroupMean(g groupDrift, counts groupCounts) float64 {
-	return meanOfPresent(
-		weightedGroupValue(g.functionWord, counts.functionWord),
-		weightedGroupValue(g.ngram, counts.ngram),
-	)
-}
-
-func weightedGroupValue(value float64, count int) float64 {
-	if count == 0 {
+	sum := 0.0
+	active := 0
+	if counts.functionWord > 0 {
+		sum += g.functionWord
+		active++
+	}
+	if counts.ngram > 0 {
+		sum += g.ngram
+		active++
+	}
+	if active == 0 {
 		return 0
 	}
-	return value
+	return sum / float64(active)
 }
 
 func registerExcess(register float64) float64 {
@@ -979,25 +997,6 @@ func (b driftBreakdown) driver() string {
 		return ""
 	}
 	return driver
-}
-
-// meanOfPresent averages the sub-signals that are actually present. A sub-signal
-// of zero means its group had no active features (e.g. the function-word group
-// for a target sharing no vocabulary, or either group when disabled), so it is
-// excluded from the average rather than dragging it toward zero.
-func meanOfPresent(values ...float64) float64 {
-	sum := 0.0
-	count := 0
-	for _, value := range values {
-		if value > 0 {
-			sum += value
-			count++
-		}
-	}
-	if count == 0 {
-		return 0
-	}
-	return sum / float64(count)
 }
 
 // ComputeSelfSimilarityStats measures, for each training document, the mean z

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -206,6 +206,13 @@ type Explanation struct {
 	SelfSimilarity *SimilarityAnchor
 }
 
+const (
+	calibratedMedianScore = 90
+	calibratedUpperScore  = 75
+	calibrationMedianFloor = 0.1
+	calibrationSpreadFloor = 0.05
+)
+
 // lowLevelExplainLimit caps how many low-level fingerprint drifts the explanation
 // reports. The full set runs to hundreds of n-grams; surfacing the top few keeps
 // the report readable while still flagging the strongest fingerprint movement.
@@ -245,6 +252,14 @@ func Score(reference feature.Distribution, target feature.Metrics, flags config.
 	}
 }
 
+// ScoreRecord is the check-time scoring path: it uses the profile's
+// self-similarity baseline when present, falling back to the legacy fixed scale
+// for old or under-specified profiles.
+func ScoreRecord(record Record, target feature.Metrics, flags config.Features) Comparison {
+	drifts := featureDrifts(record.Distribution, target, flags)
+	return comparisonFromDrifts(drifts, record.SelfSimilarity)
+}
+
 // Explain produces the rich, editor-facing view of the same comparison Score
 // makes. It reuses the identical per-feature z-scores (so the headline similarity
 // matches Score exactly), then prioritizes them for editing and, when segments
@@ -262,6 +277,26 @@ func Explain(reference feature.Distribution, target feature.Metrics, segments []
 		Segments:    locateSegmentDrift(reference, segments, flags),
 		ScoreDriver: breakdown.driver(),
 		ScoreNote:   explanationScoreNote,
+	}
+}
+
+// ExplainRecord mirrors ScoreRecord for the detailed explain path so the
+// headline similarity and the self-similarity anchor use the same calibrated
+// mapping as plain check.
+func ExplainRecord(record Record, target feature.Metrics, segments []feature.Segment, flags config.Features) Explanation {
+	drifts := featureDrifts(record.Distribution, target, flags)
+	breakdown := summarizeDrifts(drifts)
+	similarity := 100
+	if len(drifts) > 0 {
+		similarity = calibratedSimilarityFromMeanZ(breakdown.meanZ, record.SelfSimilarity)
+	}
+	return Explanation{
+		Similarity:     similarity,
+		Drifts:         prioritize(drifts),
+		Segments:       locateSegmentDrift(record.Distribution, segments, flags),
+		ScoreDriver:    breakdown.driver(),
+		ScoreNote:      explanationScoreNote,
+		SelfSimilarity: calibratedSelfSimilarityAnchor(record.SelfSimilarity),
 	}
 }
 
@@ -420,11 +455,49 @@ func summarizeDrifts(drifts []FeatureDrift) driftBreakdown {
 }
 
 func similarityFromBreakdown(b driftBreakdown) int {
-	return similarityFromMeanZ(b.meanZ)
+	return legacySimilarityFromMeanZ(b.meanZ)
 }
 
-func similarityFromMeanZ(meanZ float64) int {
+func legacySimilarityFromMeanZ(meanZ float64) int {
 	return clampPercent(int(math.Round((1 - meanZ/zScoreScale) * 100)))
+}
+
+func calibratedSimilarityFromMeanZ(meanZ float64, stats *SelfSimilarityStats) int {
+	if stats == nil || len(stats.MeanZ) == 0 {
+		return legacySimilarityFromMeanZ(meanZ)
+	}
+	median := math.Max(stats.MeanZMedian, calibrationMedianFloor)
+	spread := math.Max(stats.MeanZSpread, calibrationSpreadFloor)
+	upper := math.Max(stats.MeanZMax, median+spread)
+	width := math.Max(upper-median, calibrationSpreadFloor)
+	tailWidth := math.Max(spread*0.75, calibrationSpreadFloor)
+
+	if meanZ <= median {
+		ratio := meanZ / median
+		return clampPercent(int(math.Round(100 - ratio*(100-calibratedMedianScore))))
+	}
+	if meanZ <= upper {
+		ratio := (meanZ - median) / width
+		return clampPercent(int(math.Round(calibratedMedianScore - ratio*(calibratedMedianScore-calibratedUpperScore))))
+	}
+	ratio := (meanZ - upper) / tailWidth
+	return clampPercent(int(math.Round(calibratedUpperScore - ratio*calibratedUpperScore)))
+}
+
+func comparisonFromDrifts(drifts []FeatureDrift, stats *SelfSimilarityStats) Comparison {
+	if len(drifts) == 0 {
+		return Comparison{
+			Similarity:     100,
+			Differences:    []string{"no enabled features configured"},
+			SelfSimilarity: calibratedSelfSimilarityAnchor(stats),
+		}
+	}
+	breakdown := summarizeDrifts(drifts)
+	return Comparison{
+		Similarity:     calibratedSimilarityFromMeanZ(breakdown.meanZ, stats),
+		Differences:    topDifferences(drifts),
+		SelfSimilarity: calibratedSelfSimilarityAnchor(stats),
+	}
 }
 
 // topDifferences renders the default `check` output: the three highest-z drifts
@@ -955,16 +1028,26 @@ func ComputeSelfSimilarityStats(samples []feature.Metrics, flags config.Features
 }
 
 func SelfSimilarityAnchorForStats(stats *SelfSimilarityStats) *SimilarityAnchor {
+	return selfSimilarityAnchorForStats(stats, legacySimilarityFromMeanZ)
+}
+
+func calibratedSelfSimilarityAnchor(stats *SelfSimilarityStats) *SimilarityAnchor {
+	return selfSimilarityAnchorForStats(stats, func(meanZ float64) int {
+		return calibratedSimilarityFromMeanZ(meanZ, stats)
+	})
+}
+
+func selfSimilarityAnchorForStats(stats *SelfSimilarityStats, mapper func(float64) int) *SimilarityAnchor {
 	if stats == nil || len(stats.MeanZ) == 0 {
 		return nil
 	}
-	low := similarityFromMeanZ(stats.MeanZMax)
-	high := similarityFromMeanZ(stats.MeanZMin)
+	low := mapper(stats.MeanZMax)
+	high := mapper(stats.MeanZMin)
 	if low > high {
 		low, high = high, low
 	}
 	return &SimilarityAnchor{
-		Median:  similarityFromMeanZ(stats.MeanZMedian),
+		Median:  mapper(stats.MeanZMedian),
 		Low:     low,
 		High:    high,
 		Samples: len(stats.MeanZ),

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -35,6 +35,22 @@ type Record struct {
 	// describe a different measurement than the target being scored.
 	FeatureVersion int
 	Distribution   feature.Distribution
+	// SelfSimilarity stores the leave-one-out self-similarity baseline measured at
+	// train time. Older profiles load with nil here and follow the legacy scoring
+	// path until retrained.
+	SelfSimilarity *SelfSimilarityStats
+}
+
+// SelfSimilarityStats summarizes how far each training document sits from the
+// rest of the corpus (leave-one-out mean z-score). The raw values are kept so
+// later score mappings and output anchors can derive exact medians/ranges
+// without recomputing the corpus.
+type SelfSimilarityStats struct {
+	MeanZ       []float64
+	MeanZMedian float64
+	MeanZSpread float64
+	MeanZMin    float64
+	MeanZMax    float64
 }
 
 type Comparison struct {
@@ -171,9 +187,11 @@ type SegmentDrift struct {
 // (high-level first, then the capped low-level fingerprint) and Segments points
 // at the paragraphs that drift most.
 type Explanation struct {
-	Similarity int
-	Drifts     []FeatureDrift
-	Segments   []SegmentDrift
+	Similarity  int
+	Drifts      []FeatureDrift
+	Segments    []SegmentDrift
+	ScoreDriver string
+	ScoreNote   string
 }
 
 // lowLevelExplainLimit caps how many low-level fingerprint drifts the explanation
@@ -222,13 +240,16 @@ func Score(reference feature.Distribution, target feature.Metrics, flags config.
 func Explain(reference feature.Distribution, target feature.Metrics, segments []feature.Segment, flags config.Features) Explanation {
 	drifts := featureDrifts(reference, target, flags)
 	similarity := 100
+	breakdown := summarizeDrifts(drifts)
 	if len(drifts) > 0 {
-		similarity = similarityFromDrifts(drifts)
+		similarity = similarityFromBreakdown(breakdown)
 	}
 	return Explanation{
-		Similarity: similarity,
-		Drifts:     prioritize(drifts),
-		Segments:   locateSegmentDrift(reference, segments, flags),
+		Similarity:  similarity,
+		Drifts:      prioritize(drifts),
+		Segments:    locateSegmentDrift(reference, segments, flags),
+		ScoreDriver: breakdown.driver(),
+		ScoreNote:   explanationScoreNote,
 	}
 }
 
@@ -326,6 +347,26 @@ func featureDrifts(reference feature.Distribution, target feature.Metrics, flags
 // the structural remainder nudge. Reconstructing the group means from the drift
 // list keeps a single source of truth instead of duplicating the accumulation.
 func similarityFromDrifts(drifts []FeatureDrift) int {
+	return similarityFromBreakdown(summarizeDrifts(drifts))
+}
+
+type groupCounts struct {
+	register     int
+	other        int
+	functionWord int
+	ngram        int
+}
+
+type driftBreakdown struct {
+	groups       groupDrift
+	counts       groupCounts
+	lexicalTerm  float64
+	registerTerm float64
+	otherTerm    float64
+	meanZ        float64
+}
+
+func summarizeDrifts(drifts []FeatureDrift) driftBreakdown {
 	var registerZ, otherZ, functionWordZ, ngramZ float64
 	var registerCount, otherCount, functionWordCount, ngramCount int
 	for _, drift := range drifts {
@@ -344,13 +385,30 @@ func similarityFromDrifts(drifts []FeatureDrift) int {
 			otherCount++
 		}
 	}
-	meanZ := combineDrift(groupDrift{
+	groups := groupDrift{
 		register:     meanOf(registerZ, registerCount),
 		other:        meanOf(otherZ, otherCount),
 		functionWord: meanOf(functionWordZ, functionWordCount),
 		ngram:        meanOf(ngramZ, ngramCount),
-	})
-	return clampPercent(int(math.Round((1 - meanZ/zScoreScale) * 100)))
+	}
+	breakdown := driftBreakdown{
+		groups: groups,
+		counts: groupCounts{
+			register:     registerCount,
+			other:        otherCount,
+			functionWord: functionWordCount,
+			ngram:        ngramCount,
+		},
+	}
+	breakdown.lexicalTerm = lexicalGroupMean(groups, breakdown.counts)
+	breakdown.registerTerm = registerWeight * registerExcess(groups.register)
+	breakdown.otherTerm = otherStructWeight * groups.other
+	breakdown.meanZ = combineDrift(groups)
+	return breakdown
+}
+
+func similarityFromBreakdown(b driftBreakdown) int {
+	return clampPercent(int(math.Round((1 - b.meanZ/zScoreScale) * 100)))
 }
 
 // topDifferences renders the default `check` output: the three highest-z drifts
@@ -731,6 +789,8 @@ type groupDrift struct {
 	ngram        float64
 }
 
+const explanationScoreNote = "This score is computed from the full fingerprint and structure mix; the paragraph-level scalar drift below is supporting detail and usually contributes less than the lexical fingerprint."
+
 // combineDrift fuses the feature groups into a single drift figure. The lexical
 // fingerprint leads, since it separates same-register and English authors; it is
 // the equal-weight mean of the function-word and character-n-gram sub-signals so
@@ -740,12 +800,11 @@ type groupDrift struct {
 // register flip (an LLM imitation, cross-language text) is charged sharply. The
 // noisy structural remainder only nudges the result.
 func combineDrift(g groupDrift) float64 {
-	lexical := meanOfPresent(g.functionWord, g.ngram)
-	registerExcess := g.register - registerTolerance
-	if registerExcess < 0 {
-		registerExcess = 0
-	}
-	return lexical + registerWeight*registerExcess + otherStructWeight*g.other
+	lexical := lexicalGroupMean(g, groupCounts{
+		functionWord: boolCount(g.functionWord != 0),
+		ngram:        boolCount(g.ngram != 0),
+	})
+	return lexical + registerWeight*registerExcess(g.register) + otherStructWeight*g.other
 }
 
 // registerCompareWeight is how much a register difference between two documents
@@ -767,8 +826,57 @@ const (
 // n-gram distances), a register difference is added with a fixed weight, and the
 // remaining structural features contribute a moderate share.
 func combineCompareDrift(g groupDrift) float64 {
-	lexical := meanOfPresent(g.functionWord, g.ngram)
+	lexical := lexicalGroupMean(g, groupCounts{
+		functionWord: boolCount(g.functionWord != 0),
+		ngram:        boolCount(g.ngram != 0),
+	})
 	return lexical + registerCompareWeight*g.register + otherCompareWeight*g.other
+}
+
+func lexicalGroupMean(g groupDrift, counts groupCounts) float64 {
+	return meanOfPresent(
+		weightedGroupValue(g.functionWord, counts.functionWord),
+		weightedGroupValue(g.ngram, counts.ngram),
+	)
+}
+
+func weightedGroupValue(value float64, count int) float64 {
+	if count == 0 {
+		return 0
+	}
+	return value
+}
+
+func registerExcess(register float64) float64 {
+	excess := register - registerTolerance
+	if excess < 0 {
+		return 0
+	}
+	return excess
+}
+
+func boolCount(ok bool) int {
+	if ok {
+		return 1
+	}
+	return 0
+}
+
+func (b driftBreakdown) driver() string {
+	driver := "lexical"
+	best := b.lexicalTerm
+	if b.registerTerm > best {
+		driver = categoryRegister
+		best = b.registerTerm
+	}
+	if b.otherTerm > best {
+		driver = categoryStructure
+		best = b.otherTerm
+	}
+	if best == 0 {
+		return ""
+	}
+	return driver
 }
 
 // meanOfPresent averages the sub-signals that are actually present. A sub-signal
@@ -788,6 +896,61 @@ func meanOfPresent(values ...float64) float64 {
 		return 0
 	}
 	return sum / float64(count)
+}
+
+// ComputeSelfSimilarityStats measures, for each training document, the mean z
+// it scores against the aggregate of the other documents. The stored summary is
+// the train-time baseline that later check output and calibrated scoring reuse.
+func ComputeSelfSimilarityStats(samples []feature.Metrics, flags config.Features) *SelfSimilarityStats {
+	if len(samples) < 2 {
+		return nil
+	}
+	values := make([]float64, 0, len(samples))
+	for i, sample := range samples {
+		others := make([]feature.Metrics, 0, len(samples)-1)
+		others = append(others, samples[:i]...)
+		others = append(others, samples[i+1:]...)
+		drifts := featureDrifts(feature.Aggregate(others), sample, flags)
+		values = append(values, summarizeDrifts(drifts).meanZ)
+	}
+	sorted := append([]float64(nil), values...)
+	sort.Float64s(sorted)
+
+	return &SelfSimilarityStats{
+		MeanZ:       values,
+		MeanZMedian: median(sorted),
+		MeanZSpread: populationStdDev(values),
+		MeanZMin:    sorted[0],
+		MeanZMax:    sorted[len(sorted)-1],
+	}
+}
+
+func median(sorted []float64) float64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	mid := len(sorted) / 2
+	if len(sorted)%2 == 1 {
+		return sorted[mid]
+	}
+	return (sorted[mid-1] + sorted[mid]) / 2
+}
+
+func populationStdDev(values []float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	mean := 0.0
+	for _, value := range values {
+		mean += value
+	}
+	mean /= float64(len(values))
+	variance := 0.0
+	for _, value := range values {
+		diff := value - mean
+		variance += diff * diff
+	}
+	return math.Sqrt(variance / float64(len(values)))
 }
 
 // meanOf reduces a running z-score sum to its mean, returning zero for an empty

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -53,9 +53,20 @@ type SelfSimilarityStats struct {
 	MeanZMax    float64
 }
 
+// SimilarityAnchor is the human-facing summary of the author's own
+// leave-one-out self-similarity band, expressed in the same 0-100 scale check
+// prints. Low/High are the observed range of self-similarity scores.
+type SimilarityAnchor struct {
+	Median  int
+	Low     int
+	High    int
+	Samples int
+}
+
 type Comparison struct {
-	Similarity  int
-	Differences []string
+	Similarity     int
+	Differences    []string
+	SelfSimilarity *SimilarityAnchor
 }
 
 // zScoreScale maps the mean absolute z-score to a similarity percentage: a
@@ -187,11 +198,12 @@ type SegmentDrift struct {
 // (high-level first, then the capped low-level fingerprint) and Segments points
 // at the paragraphs that drift most.
 type Explanation struct {
-	Similarity  int
-	Drifts      []FeatureDrift
-	Segments    []SegmentDrift
-	ScoreDriver string
-	ScoreNote   string
+	Similarity     int
+	Drifts         []FeatureDrift
+	Segments       []SegmentDrift
+	ScoreDriver    string
+	ScoreNote      string
+	SelfSimilarity *SimilarityAnchor
 }
 
 // lowLevelExplainLimit caps how many low-level fingerprint drifts the explanation
@@ -408,7 +420,11 @@ func summarizeDrifts(drifts []FeatureDrift) driftBreakdown {
 }
 
 func similarityFromBreakdown(b driftBreakdown) int {
-	return clampPercent(int(math.Round((1 - b.meanZ/zScoreScale) * 100)))
+	return similarityFromMeanZ(b.meanZ)
+}
+
+func similarityFromMeanZ(meanZ float64) int {
+	return clampPercent(int(math.Round((1 - meanZ/zScoreScale) * 100)))
 }
 
 // topDifferences renders the default `check` output: the three highest-z drifts
@@ -922,6 +938,23 @@ func ComputeSelfSimilarityStats(samples []feature.Metrics, flags config.Features
 		MeanZSpread: populationStdDev(values),
 		MeanZMin:    sorted[0],
 		MeanZMax:    sorted[len(sorted)-1],
+	}
+}
+
+func SelfSimilarityAnchorForStats(stats *SelfSimilarityStats) *SimilarityAnchor {
+	if stats == nil || len(stats.MeanZ) == 0 {
+		return nil
+	}
+	low := similarityFromMeanZ(stats.MeanZMax)
+	high := similarityFromMeanZ(stats.MeanZMin)
+	if low > high {
+		low, high = high, low
+	}
+	return &SimilarityAnchor{
+		Median:  similarityFromMeanZ(stats.MeanZMedian),
+		Low:     low,
+		High:    high,
+		Samples: len(stats.MeanZ),
 	}
 }
 

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -874,8 +874,10 @@ const (
 	// before it counts as a register shift. Only the excess above this hinge is
 	// charged, so a genuine same-register document is untouched while a wholesale
 	// register flip — an LLM imitation in the opposite register, or cross-language
-	// text whose register features collapse to zero — is penalized sharply.
-	registerTolerance = 2.5
+	// text whose register features collapse to zero — is penalized sharply. 3.0
+	// leaves roughly a 0.06 ratio shift inside the free band under the 0.02 ratio
+	// std floor, which better matches the author's own mild register wobble.
+	registerTolerance = 3.0
 )
 
 // groupDrift holds the mean z-score of each feature group for a single

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -413,7 +413,7 @@ func summarizeDrifts(drifts []FeatureDrift) driftBreakdown {
 		},
 	}
 	breakdown.lexicalTerm = lexicalGroupMean(groups, breakdown.counts)
-	breakdown.registerTerm = registerWeight * registerExcess(groups.register)
+	breakdown.registerTerm = registerWeight * registerPenalty(groups.register)
 	breakdown.otherTerm = otherStructWeight * groups.other
 	breakdown.meanZ = combineDrift(groups)
 	return breakdown
@@ -784,6 +784,11 @@ var registerLabels = map[string]bool{
 const (
 	registerWeight    = 1.0
 	otherStructWeight = 0.05
+	// registerSaturation caps the register penalty once the drift is already
+	// clearly far outside the author's normal range. This prevents the ratio-floor
+	// artifact from collapsing both "register flipped but otherwise identical" and
+	// "wholly different author" to the same 0% score.
+	registerSaturation = 2.0
 	// registerTolerance is the register z-score an author may reach through their
 	// own variation (e.g. nao writes mostly 敬体 but slips into 常体 in some posts)
 	// before it counts as a register shift. Only the excess above this hinge is
@@ -812,15 +817,15 @@ const explanationScoreNote = "This score is computed from the full fingerprint a
 // the equal-weight mean of the function-word and character-n-gram sub-signals so
 // that neither the ~150 function words nor the ~400 n-grams dominate by sheer
 // count. The register group is added only for its excess above registerTolerance,
-// so an author's own mild register variation is ignored while a wholesale
-// register flip (an LLM imitation, cross-language text) is charged sharply. The
-// noisy structural remainder only nudges the result.
+// but that excess saturates once it is clearly "far enough", restoring
+// resolution between a near-match with the wrong register and a wholly different
+// author. The noisy structural remainder only nudges the result.
 func combineDrift(g groupDrift) float64 {
 	lexical := lexicalGroupMean(g, groupCounts{
 		functionWord: boolCount(g.functionWord != 0),
 		ngram:        boolCount(g.ngram != 0),
 	})
-	return lexical + registerWeight*registerExcess(g.register) + otherStructWeight*g.other
+	return lexical + registerWeight*registerPenalty(g.register) + otherStructWeight*g.other
 }
 
 // registerCompareWeight is how much a register difference between two documents
@@ -869,6 +874,14 @@ func registerExcess(register float64) float64 {
 		return 0
 	}
 	return excess
+}
+
+func registerPenalty(register float64) float64 {
+	excess := registerExcess(register)
+	if excess == 0 {
+		return 0
+	}
+	return registerSaturation * math.Tanh(excess/registerSaturation)
 }
 
 func boolCount(ok bool) int {

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -154,6 +154,74 @@ func TestScoreRejectsCrossLanguageText(t *testing.T) {
 	}
 }
 
+func TestScoreRecordFallsBackWithoutCalibration(t *testing.T) {
+	t.Parallel()
+
+	flags := config.Default("sample").Features
+	polite := []string{
+		"今日は朝から雨が降っています。傘を持って出かけました。電車はとても混んでいました。",
+		"昨日は友人と食事に行きました。料理はどれも美味しかったです。また行きたいと思います。",
+		"週末は近くの公園を散歩しました。空気が澄んでいて気持ちが良かったです。",
+	}
+	dist := distributionFromTexts(polite)
+	target := feature.ExtractText("今日は良い天気です。散歩に出かけました。とても気持ちが良かったです。")
+
+	legacy := Score(dist, target, flags)
+	record := Record{Distribution: dist}
+	calibrated := ScoreRecord(record, target, flags)
+	if calibrated.Similarity != legacy.Similarity {
+		t.Fatalf("expected legacy fallback without calibration: legacy=%d calibrated=%d",
+			legacy.Similarity, calibrated.Similarity)
+	}
+}
+
+func TestScoreRecordCalibratesSelfSimilarity(t *testing.T) {
+	t.Parallel()
+
+	flags := config.Default("sample").Features
+	texts := []string{
+		"今日は朝から雨が降っています。傘を持って出かけました。電車はとても混んでいました。",
+		"昨日は友人と食事に行きました。料理はどれも美味しかったです。また行きたいと思います。",
+		"週末は近くの公園を散歩しました。空気が澄んでいて気持ちが良かったです。",
+		"新しい本を買いました。内容がとても面白くて一気に読み終えました。",
+		"先週は仕事が忙しかったです。それでも毎日きちんと休めました。",
+	}
+	perDoc := make([]feature.Metrics, 0, len(texts))
+	for _, text := range texts {
+		perDoc = append(perDoc, feature.ExtractText(text))
+	}
+	record := Record{
+		Distribution:   feature.Aggregate(perDoc),
+		SelfSimilarity: ComputeSelfSimilarityStats(perDoc, flags),
+	}
+
+	own := feature.ExtractText("今日は朝から少し雨が降っています。傘を持って出かけました。空気が冷たくて静かでした。")
+	other := feature.ExtractText("きょうもサッカーをしたよ。仲間と思いきり走ったんだ。最高に楽しい一日だったなあ。")
+
+	legacyOwn := Score(record.Distribution, own, flags)
+	calibratedOwn := ScoreRecord(record, own, flags)
+	calibratedOther := ScoreRecord(record, other, flags)
+
+	if calibratedOwn.SelfSimilarity == nil || calibratedOwn.SelfSimilarity.Median != calibratedMedianScore {
+		t.Fatalf("expected calibrated self-similarity anchor at %d, got %+v",
+			calibratedMedianScore, calibratedOwn.SelfSimilarity)
+	}
+	if calibratedOwn.Similarity <= legacyOwn.Similarity {
+		t.Fatalf("expected calibration to lift own-text scores: legacy=%d calibrated=%d",
+			legacyOwn.Similarity, calibratedOwn.Similarity)
+	}
+	if calibratedOwn.Similarity < 85 {
+		t.Fatalf("expected own-text score to move near the calibrated anchor, got %d", calibratedOwn.Similarity)
+	}
+	if calibratedOther.Similarity >= calibratedOwn.Similarity {
+		t.Fatalf("expected other author to remain below own text: own=%d other=%d",
+			calibratedOwn.Similarity, calibratedOther.Similarity)
+	}
+	if calibratedOther.Similarity >= 50 {
+		t.Fatalf("expected other author to stay clearly low after calibration, got %d", calibratedOther.Similarity)
+	}
+}
+
 func TestScoreSeparatesLexicalFingerprint(t *testing.T) {
 	t.Parallel()
 
@@ -189,6 +257,33 @@ func TestExplainMatchesScoreSimilarity(t *testing.T) {
 	explanation := Explain(dist, target, nil, flags)
 	if explanation.Similarity != score.Similarity {
 		t.Fatalf("Explain similarity %d should match Score similarity %d",
+			explanation.Similarity, score.Similarity)
+	}
+}
+
+func TestExplainRecordMatchesScoreRecordSimilarity(t *testing.T) {
+	t.Parallel()
+
+	flags := config.Default("sample").Features
+	texts := []string{
+		"今日は朝から雨が降っています。傘を持って出かけました。電車はとても混んでいました。",
+		"昨日は友人と食事に行きました。料理はどれも美味しかったです。また行きたいと思います。",
+		"週末は近くの公園を散歩しました。空気が澄んでいて気持ちが良かったです。",
+	}
+	perDoc := make([]feature.Metrics, 0, len(texts))
+	for _, text := range texts {
+		perDoc = append(perDoc, feature.ExtractText(text))
+	}
+	record := Record{
+		Distribution:   feature.Aggregate(perDoc),
+		SelfSimilarity: ComputeSelfSimilarityStats(perDoc, flags),
+	}
+	target := feature.ExtractText("今日は良い天気です。散歩に出かけました。とても気持ちが良かったです。")
+
+	score := ScoreRecord(record, target, flags)
+	explanation := ExplainRecord(record, target, nil, flags)
+	if explanation.Similarity != score.Similarity {
+		t.Fatalf("ExplainRecord similarity %d should match ScoreRecord similarity %d",
 			explanation.Similarity, score.Similarity)
 	}
 }

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -134,6 +134,49 @@ func TestRegisterFlipRetainsLexicalResolution(t *testing.T) {
 	}
 }
 
+func TestExactLexicalMatchBeatsTinyLexicalDrift(t *testing.T) {
+	t.Parallel()
+
+	exact := []FeatureDrift{
+		{Category: categoryFunctionWord, Z: 0},
+		{Category: categoryCharNgram, Z: 2},
+	}
+	epsilon := []FeatureDrift{
+		{Category: categoryFunctionWord, Z: 0.1},
+		{Category: categoryCharNgram, Z: 2},
+	}
+
+	exactBreakdown := summarizeDrifts(exact)
+	epsilonBreakdown := summarizeDrifts(epsilon)
+	if math.Abs(exactBreakdown.lexicalTerm-1.0) > 1e-9 {
+		t.Fatalf("expected exact lexical match to average with the active n-gram group, got %f", exactBreakdown.lexicalTerm)
+	}
+	if exactBreakdown.meanZ >= epsilonBreakdown.meanZ {
+		t.Fatalf("expected exact lexical match to produce a lower mean z: exact=%f epsilon=%f",
+			exactBreakdown.meanZ, epsilonBreakdown.meanZ)
+	}
+	if similarityFromDrifts(exact) <= similarityFromDrifts(epsilon) {
+		t.Fatalf("expected an exact lexical match to score better than a tiny drift: exact=%d epsilon=%d",
+			similarityFromDrifts(exact), similarityFromDrifts(epsilon))
+	}
+}
+
+func TestCompareCountsExactLexicalMatchesAsPresent(t *testing.T) {
+	t.Parallel()
+
+	got := combineCompareDriftWithCounts(groupDrift{
+		functionWord: 0,
+		ngram:        0.4,
+	}, groupCounts{
+		functionWord: 1,
+		ngram:        1,
+	})
+	want := 0.2
+	if math.Abs(got-want) > 1e-9 {
+		t.Fatalf("expected exact function-word match to stay in the lexical mean: got=%f want=%f", got, want)
+	}
+}
+
 func TestScoreRejectsCrossLanguageText(t *testing.T) {
 	t.Parallel()
 

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -1,6 +1,7 @@
 package profile
 
 import (
+	"math"
 	"strings"
 	"testing"
 
@@ -62,6 +63,74 @@ func TestScoreDetectsRegisterShift(t *testing.T) {
 	if plainScore.Similarity >= politeScore.Similarity {
 		t.Fatalf("expected a register shift to lower similarity: polite=%d plain=%d",
 			politeScore.Similarity, plainScore.Similarity)
+	}
+}
+
+func TestRegisterPenaltySaturates(t *testing.T) {
+	t.Parallel()
+
+	values := []float64{
+		registerPenalty(3),
+		registerPenalty(5),
+		registerPenalty(10),
+		registerPenalty(50),
+	}
+	for i := 1; i < len(values); i++ {
+		if values[i] < values[i-1] {
+			t.Fatalf("register penalty should be monotonic: %#v", values)
+		}
+	}
+	if values[len(values)-1] > registerSaturation {
+		t.Fatalf("register penalty should stay within the saturation cap %.2f, got %.6f",
+			registerSaturation, values[len(values)-1])
+	}
+	if math.Abs(values[len(values)-1]-values[len(values)-2]) > 0.1 {
+		t.Fatalf("register penalty should flatten out by large z, got %#v", values)
+	}
+}
+
+func TestRegisterPenaltyLeavesToleranceRegionUntouched(t *testing.T) {
+	t.Parallel()
+
+	got := combineDrift(groupDrift{
+		register:     registerTolerance,
+		functionWord: 0.6,
+		ngram:        0.4,
+		other:        1.0,
+	})
+	want := 0.5 + otherStructWeight*1.0
+	if math.Abs(got-want) > 1e-9 {
+		t.Fatalf("register within tolerance should add nothing: got=%f want=%f", got, want)
+	}
+}
+
+func TestRegisterFlipRetainsLexicalResolution(t *testing.T) {
+	t.Parallel()
+
+	flags := config.Default("sample").Features
+	polite := []string{
+		"今日は朝から雨が降っています。傘を持って出かけました。電車はとても混んでいました。",
+		"昨日は友人と食事に行きました。料理はどれも美味しかったです。また行きたいと思います。",
+		"週末は近くの公園を散歩しました。空気が澄んでいて気持ちが良かったです。",
+		"新しい本を買いました。内容がとても面白くて一気に読み終えました。",
+		"先週は仕事が忙しかったです。それでも毎日きちんと休めました。",
+	}
+	dist := distributionFromTexts(polite)
+
+	// Same lexical fingerprint and structure as the profile mean, but with a full
+	// register flip. This used to collapse to 0% together with a genuinely
+	// different author because the register excess was unbounded.
+	registerFlip := dist.Mean
+	registerFlip.PoliteEndingRatio = 0
+	registerFlip.PlainEndingRatio = 1
+
+	otherAuthor := feature.ExtractText("本日は降雨である。会議資料を作成した。結論を整理し、対応を決定した。")
+
+	near := Score(dist, registerFlip, flags)
+	far := Score(dist, otherAuthor, flags)
+	if near.Similarity <= far.Similarity {
+		t.Fatalf("register-flipped near match should outscore a different author: near=%d far=%d",
+			near.Similarity, far.Similarity)
 	}
 }
 

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -104,6 +104,17 @@ func TestRegisterPenaltyLeavesToleranceRegionUntouched(t *testing.T) {
 	}
 }
 
+func TestRegisterToleranceAllowsMildVariation(t *testing.T) {
+	t.Parallel()
+
+	if registerPenalty(2.9) != 0 {
+		t.Fatalf("mild register wobble should stay inside tolerance, got penalty %f", registerPenalty(2.9))
+	}
+	if registerPenalty(3.1) <= 0 {
+		t.Fatalf("register drift above tolerance should be charged, got %f", registerPenalty(3.1))
+	}
+}
+
 func TestRegisterFlipRetainsLexicalResolution(t *testing.T) {
 	t.Parallel()
 

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -62,7 +62,8 @@ CREATE TABLE IF NOT EXISTS profile (
   mean_pos_ngrams TEXT NOT NULL DEFAULT '{}',
   std_pos_ngrams TEXT NOT NULL DEFAULT '{}',
   sources TEXT NOT NULL DEFAULT '[]',
-  quality_findings TEXT NOT NULL DEFAULT '[]'
+  quality_findings TEXT NOT NULL DEFAULT '[]',
+  self_similarity_stats TEXT
 );
 
 -- Term preferences are profile-local: this database holds exactly one author's
@@ -102,6 +103,7 @@ func migrate(ctx context.Context, db *sql.DB) error {
 		`ALTER TABLE profile ADD COLUMN feature_version INTEGER NOT NULL DEFAULT 1`,
 		`ALTER TABLE profile ADD COLUMN mean_type_token_ratio REAL NOT NULL DEFAULT 0`,
 		`ALTER TABLE profile ADD COLUMN std_type_token_ratio REAL NOT NULL DEFAULT 0`,
+		`ALTER TABLE profile ADD COLUMN self_similarity_stats TEXT`,
 	} {
 		if _, err := db.ExecContext(ctx, column); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
 			return err
@@ -144,9 +146,10 @@ INSERT INTO profile (
   std_polite_ending_ratio, std_plain_ending_ratio, std_type_token_ratio,
   document_count, sentence_count, character_count,
   mean_lexical_frequencies, std_lexical_frequencies,
-  mean_char_ngrams, std_char_ngrams, mean_pos_ngrams, std_pos_ngrams, sources
+  mean_char_ngrams, std_char_ngrams, mean_pos_ngrams, std_pos_ngrams, sources,
+  self_similarity_stats
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(id) DO UPDATE SET
   author = excluded.author,
   source_dir = excluded.source_dir,
@@ -190,7 +193,8 @@ ON CONFLICT(id) DO UPDATE SET
   std_char_ngrams = excluded.std_char_ngrams,
   mean_pos_ngrams = excluded.mean_pos_ngrams,
   std_pos_ngrams = excluded.std_pos_ngrams,
-  sources = excluded.sources;
+  sources = excluded.sources,
+  self_similarity_stats = excluded.self_similarity_stats;
 `
 
 	mean := record.Distribution.Mean
@@ -242,6 +246,7 @@ ON CONFLICT(id) DO UPDATE SET
 		marshalLexical(mean.POSNgrams),
 		marshalLexical(std.POSNgrams),
 		marshalSources(record.Sources),
+		marshalSelfSimilarity(record.SelfSimilarity),
 	)
 	return err
 }
@@ -279,6 +284,17 @@ func marshalLexical(vector map[string]float64) string {
 	encoded, err := json.Marshal(vector)
 	if err != nil {
 		return "{}"
+	}
+	return string(encoded)
+}
+
+func marshalSelfSimilarity(stats *profile.SelfSimilarityStats) any {
+	if stats == nil {
+		return nil
+	}
+	encoded, err := json.Marshal(stats)
+	if err != nil {
+		return nil
 	}
 	return string(encoded)
 }
@@ -350,7 +366,8 @@ SELECT
   std_char_ngrams,
   mean_pos_ngrams,
   std_pos_ngrams,
-  sources
+  sources,
+  self_similarity_stats
 FROM profile
 WHERE id = 1
 `)
@@ -363,6 +380,7 @@ WHERE id = 1
 	var meanPOSNgramJSON string
 	var stdPOSNgramJSON string
 	var sourcesJSON string
+	var selfSimilarityJSON sql.NullString
 	var record profile.Record
 	var mean feature.Metrics
 	var std feature.Metrics
@@ -411,6 +429,7 @@ WHERE id = 1
 		&meanPOSNgramJSON,
 		&stdPOSNgramJSON,
 		&sourcesJSON,
+		&selfSimilarityJSON,
 	); err != nil {
 		if err == sql.ErrNoRows {
 			return profile.Record{}, fmt.Errorf("profile not found: %s", path)
@@ -432,6 +451,7 @@ WHERE id = 1
 	dist.StdDev = std
 	record.Distribution = dist
 	record.Sources = unmarshalSources(sourcesJSON)
+	record.SelfSimilarity = unmarshalSelfSimilarity(selfSimilarityJSON)
 	// A profile trained before multi-input support has no sources list. Populate it
 	// from the single SourceDir so every consumer can rely on Sources being set.
 	if len(record.Sources) == 0 && record.SourceDir != "" {
@@ -464,4 +484,15 @@ func unmarshalLexical(encoded string) map[string]float64 {
 		return make(map[string]float64)
 	}
 	return vector
+}
+
+func unmarshalSelfSimilarity(encoded sql.NullString) *profile.SelfSimilarityStats {
+	if !encoded.Valid || encoded.String == "" {
+		return nil
+	}
+	var stats profile.SelfSimilarityStats
+	if err := json.Unmarshal([]byte(encoded.String), &stats); err != nil {
+		return nil
+	}
+	return &stats
 }

--- a/internal/storage/sqlite_test.go
+++ b/internal/storage/sqlite_test.go
@@ -18,6 +18,13 @@ func TestSaveLoadProfile(t *testing.T) {
 		SourceDir: "/tmp/corpus",
 		TrainedAt: time.Date(2026, time.June, 1, 12, 0, 0, 0, time.UTC),
 		FileCount: 3,
+		SelfSimilarity: &profile.SelfSimilarityStats{
+			MeanZ:       []float64{0.4, 0.6, 0.8},
+			MeanZMedian: 0.6,
+			MeanZSpread: 0.1632993161855452,
+			MeanZMin:    0.4,
+			MeanZMax:    0.8,
+		},
 		Distribution: feature.Distribution{
 			Mean: feature.Metrics{
 				AverageSentenceLength:    12,
@@ -103,6 +110,15 @@ func TestSaveLoadProfile(t *testing.T) {
 	}
 	if got := actual.Distribution.StdDev.CharNgrams["です"]; got != 0.002 {
 		t.Fatalf("std char n-gram mismatch: got=%f want=%f", got, 0.002)
+	}
+	if actual.SelfSimilarity == nil {
+		t.Fatal("expected self-similarity stats to round-trip")
+	}
+	if actual.SelfSimilarity.MeanZMedian != expected.SelfSimilarity.MeanZMedian {
+		t.Fatalf("self-similarity median mismatch: got=%f want=%f", actual.SelfSimilarity.MeanZMedian, expected.SelfSimilarity.MeanZMedian)
+	}
+	if len(actual.SelfSimilarity.MeanZ) != len(expected.SelfSimilarity.MeanZ) {
+		t.Fatalf("self-similarity sample count mismatch: got=%d want=%d", len(actual.SelfSimilarity.MeanZ), len(expected.SelfSimilarity.MeanZ))
 	}
 }
 


### PR DESCRIPTION
## Summary
- store a per-profile leave-one-out self-similarity baseline and show it in check output
- calibrate check scores to that baseline, saturate register drift, and fix exact-match handling in grouped lexical drift
- refresh the README and changelog to match the new scoring behavior

## Validation
- go test ./...
- make bench
- make test-e2e
- reproduced leave-one-out behavior on debimate/content/post/ja