### PR TITLE
docs: cut the 0.5.0 release in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and per-release binaries and notes are published from git tags by GoReleaser.
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-06-12
+
 ### Added
 
 - Training now records a leave-one-out self-similarity baseline per profile.


### PR DESCRIPTION
## Summary
- cut the 0.5.0 release entry in CHANGELOG.md
- leave Unreleased open for follow-up work

## Validation
- no code changes
- release entry is based on merged PR #12