### PR TITLE
feat(explain): add segment_style_drift, a median per-paragraph drift aggregate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and per-release binaries and notes are published from git tags by GoReleaser.
 
 ## [Unreleased]
 
+### Added
+
+- `check --explain` / `check --format json` now report `segment_style_drift`, the
+  median per-paragraph localizable drift (register, script balance, and
+  sentence-shape features). It is a robust, document-level companion to the
+  worst-paragraph list — "how far does a typical paragraph stray" rather than only
+  the single worst one — and is reported for insight only: it never affects the
+  similarity score. The JSON field is additive, so existing consumers are
+  unaffected.
+
 ### Changed
 
 - Topic-heavy technical tokens — repository names (`owner/repo`), dotted

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ High-level style differences (fix these first):
        target 292.3  reference 40.4 ± 1.540  (62.3σ)
   ...
 
+Typical paragraph drift (median): 18.7σ
 Paragraphs that drift most:
   #2 (74.9σ; average sentence length higher): Subsequently, a notebook is utilized for the purpo…
 ```
@@ -140,7 +141,7 @@ Paragraphs that drift most:
 
 ## Using omokage with an LLM
 
-Train once, then have the agent run `check --format json` after each rewrite. The JSON leads with `high_level_drift`, the editable features, each with a `priority` and `actionable` flag; `segments` points at the paragraphs that drift most, and `term_warnings` flags notation that differs from your learned preference. For a lighter payload, `show --author me --format json --summary` returns provenance and the quality rating without the often large term list. omokage tells the agent how close the draft sits to your voice and where it strays, not whether it is correct or good, so keep a human in the loop.
+Train once, then have the agent run `check --format json` after each rewrite. The JSON leads with `high_level_drift`, the editable features, each with a `priority` and `actionable` flag; `segments` points at the paragraphs that drift most, `segment_style_drift` summarizes how far a typical paragraph strays (the median per-paragraph drift, reported for insight only — it never affects the score), and `term_warnings` flags notation that differs from your learned preference. For a lighter payload, `show --author me --format json --summary` returns provenance and the quality rating without the often large term list. omokage tells the agent how close the draft sits to your voice and where it strays, not whether it is correct or good, so keep a human in the loop.
 
 ## Term preferences
 

--- a/cmd/app_test.go
+++ b/cmd/app_test.go
@@ -163,6 +163,7 @@ func TestCheckJSONOutput(t *testing.T) {
 			Z         float64 `json:"z"`
 			Direction string  `json:"direction"`
 		} `json:"segments"`
+		SegmentStyleDrift float64 `json:"segment_style_drift"`
 	}
 	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
 		t.Fatalf("check --format json did not emit valid JSON: %v\n%s", err, stdout)
@@ -203,6 +204,11 @@ func TestCheckJSONOutput(t *testing.T) {
 	}
 	if payload.Segments[0].Feature != "polite sentence-ending ratio" {
 		t.Fatalf("expected register drift to lead the localization, got %q", payload.Segments[0].Feature)
+	}
+	// The register-flipped draft strays in every paragraph, so the median
+	// paragraph drift aggregate must be present and clearly positive.
+	if payload.SegmentStyleDrift <= 0 {
+		t.Fatalf("expected a positive segment_style_drift for the register-flipped draft, got %.3f", payload.SegmentStyleDrift)
 	}
 }
 

--- a/cmd/explain.go
+++ b/cmd/explain.go
@@ -54,6 +54,9 @@ func renderExplanationText(w io.Writer, author string, explanation profile.Expla
 	}
 
 	writeLine(w)
+	if explanation.SegmentStyleDrift > 0 {
+		writef(w, "Typical paragraph drift (median): %.1fσ\n", explanation.SegmentStyleDrift)
+	}
 	if len(explanation.Segments) == 0 {
 		// Reported only in the detailed view, so silence here is informative, not a
 		// gap: no single paragraph holds an editable, paragraph-local drift worth
@@ -76,15 +79,16 @@ func renderExplanationText(w io.Writer, author string, explanation profile.Expla
 func renderExplanationJSON(w io.Writer, author string, explanation profile.Explanation, warnings []term.Warning) error {
 	high, low := splitDrifts(explanation.Drifts)
 	payload := explanationJSON{
-		Author:         author,
-		Similarity:     explanation.Similarity,
-		SelfSimilarity: toAnchorJSON(explanation.SelfSimilarity),
-		ScoreDriver:    explanation.ScoreDriver,
-		ScoreNote:      explanation.ScoreNote,
-		HighLevelDrift: toDriftJSON(high),
-		LowLevelDrift:  toDriftJSON(low),
-		Segments:       toSegmentJSON(explanation.Segments),
-		TermWarnings:   toTermWarningJSON(warnings),
+		Author:            author,
+		Similarity:        explanation.Similarity,
+		SelfSimilarity:    toAnchorJSON(explanation.SelfSimilarity),
+		ScoreDriver:       explanation.ScoreDriver,
+		ScoreNote:         explanation.ScoreNote,
+		HighLevelDrift:    toDriftJSON(high),
+		LowLevelDrift:     toDriftJSON(low),
+		Segments:          toSegmentJSON(explanation.Segments),
+		SegmentStyleDrift: round4(explanation.SegmentStyleDrift),
+		TermWarnings:      toTermWarningJSON(warnings),
 	}
 	encoder := json.NewEncoder(w)
 	encoder.SetIndent("", "  ")
@@ -92,14 +96,19 @@ func renderExplanationJSON(w io.Writer, author string, explanation profile.Expla
 }
 
 type explanationJSON struct {
-	Author         string             `json:"author"`
-	Similarity     int                `json:"similarity"`
+	Author         string                `json:"author"`
+	Similarity     int                   `json:"similarity"`
 	SelfSimilarity *similarityAnchorJSON `json:"self_similarity_anchor,omitempty"`
-	ScoreDriver    string             `json:"score_driver,omitempty"`
-	ScoreNote      string             `json:"score_note,omitempty"`
-	HighLevelDrift []featureDriftJSON `json:"high_level_drift"`
-	LowLevelDrift  []featureDriftJSON `json:"low_level_drift"`
-	Segments       []segmentJSON      `json:"segments"`
+	ScoreDriver    string                `json:"score_driver,omitempty"`
+	ScoreNote      string                `json:"score_note,omitempty"`
+	HighLevelDrift []featureDriftJSON    `json:"high_level_drift"`
+	LowLevelDrift  []featureDriftJSON    `json:"low_level_drift"`
+	Segments       []segmentJSON         `json:"segments"`
+	// SegmentStyleDrift is the median per-paragraph localizable drift (mean z of
+	// register, script, and sentence-shape features). It is a robust, document-level
+	// companion to the worst-paragraph list in Segments and is reported for insight
+	// only — it never affects similarity. Always present so the shape is stable.
+	SegmentStyleDrift float64 `json:"segment_style_drift"`
 	// TermWarnings reports notation deviations (a non-preferred surface in the
 	// draft). It is a separate layer from the similarity score and never affects
 	// it. Always present (empty array, not null) so the shape is stable.

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -204,6 +204,13 @@ type Explanation struct {
 	ScoreDriver    string
 	ScoreNote      string
 	SelfSimilarity *SimilarityAnchor
+	// SegmentStyleDrift is the median, across the document's prose paragraphs, of
+	// each paragraph's localizable drift (the mean z of its register, script, and
+	// sentence-shape features against the author). It summarizes how far a typical
+	// paragraph strays — a robust counterpart to the single worst paragraph in
+	// Segments. It is reported for insight only and never feeds Similarity, so the
+	// headline score is unchanged by it.
+	SegmentStyleDrift float64
 }
 
 const (
@@ -272,11 +279,12 @@ func Explain(reference feature.Distribution, target feature.Metrics, segments []
 		similarity = similarityFromBreakdown(breakdown)
 	}
 	return Explanation{
-		Similarity:  similarity,
-		Drifts:      prioritize(drifts),
-		Segments:    locateSegmentDrift(reference, segments, flags),
-		ScoreDriver: breakdown.driver(),
-		ScoreNote:   explanationScoreNote,
+		Similarity:        similarity,
+		Drifts:            prioritize(drifts),
+		Segments:          locateSegmentDrift(reference, segments, flags),
+		ScoreDriver:       breakdown.driver(),
+		ScoreNote:         explanationScoreNote,
+		SegmentStyleDrift: segmentStyleDrift(reference, segments, flags),
 	}
 }
 
@@ -291,12 +299,13 @@ func ExplainRecord(record Record, target feature.Metrics, segments []feature.Seg
 		similarity = calibratedSimilarityFromMeanZ(breakdown.meanZ, record.SelfSimilarity)
 	}
 	return Explanation{
-		Similarity:     similarity,
-		Drifts:         prioritize(drifts),
-		Segments:       locateSegmentDrift(record.Distribution, segments, flags),
-		ScoreDriver:    breakdown.driver(),
-		ScoreNote:      explanationScoreNote,
-		SelfSimilarity: calibratedSelfSimilarityAnchor(record.SelfSimilarity),
+		Similarity:        similarity,
+		Drifts:            prioritize(drifts),
+		Segments:          locateSegmentDrift(record.Distribution, segments, flags),
+		ScoreDriver:       breakdown.driver(),
+		ScoreNote:         explanationScoreNote,
+		SelfSimilarity:    calibratedSelfSimilarityAnchor(record.SelfSimilarity),
+		SegmentStyleDrift: segmentStyleDrift(record.Distribution, segments, flags),
 	}
 }
 
@@ -647,6 +656,32 @@ func locateSegmentDrift(reference feature.Distribution, segments []feature.Segme
 		out = out[:segmentExplainLimit]
 	}
 	return out
+}
+
+// segmentStyleDrift summarizes how far a typical paragraph strays from the author,
+// as the median over the document's prose paragraphs of each paragraph's
+// localizable drift (the mean z of its register, script, and sentence-shape
+// features). It reuses the same localizable feature subset and per-paragraph
+// minimum length as locateSegmentDrift, so the two agree on which paragraphs
+// count, but reduces them to one robust figure rather than naming the single
+// worst one. It is informational only — no caller feeds it into Similarity — so a
+// document with too few prose paragraphs to judge simply returns 0.
+func segmentStyleDrift(reference feature.Distribution, segments []feature.Segment, flags config.Features) float64 {
+	if len(segments) == 0 {
+		return 0
+	}
+	drifts := make([]float64, 0, len(segments))
+	for _, segment := range segments {
+		if segment.Metrics.CharacterCount < minSegmentContentRunes {
+			continue
+		}
+		drifts = append(drifts, DocumentDivergence(reference, segment.Metrics, flags))
+	}
+	if len(drifts) == 0 {
+		return 0
+	}
+	sort.Float64s(drifts)
+	return median(drifts)
 }
 
 // everySpec selects every feature; it is the include predicate for whole-document

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -630,6 +630,48 @@ func abs(n int) int {
 	return n
 }
 
+// TestSegmentStyleDriftRanksAndStaysOutOfScoring checks the v2 paragraph-level
+// aggregate: a draft whose paragraphs stray further from the author yields a
+// larger median paragraph drift than a matching draft, and the figure is reported
+// without changing the headline similarity (it never feeds scoring).
+func TestSegmentStyleDriftRanksAndStaysOutOfScoring(t *testing.T) {
+	t.Parallel()
+
+	flags := config.Default("sample").Features
+	polite := []string{
+		"今日は朝から雨が降っています。傘を持って出かけました。電車はとても混んでいました。",
+		"昨日は友人と食事に行きました。料理はどれも美味しかったです。また行きたいと思います。",
+		"週末は近くの公園を散歩しました。空気が澄んでいて気持ちが良かったです。",
+		"新しい本を買いました。内容がとても面白くて一気に読み終えました。",
+		"先週は仕事が忙しかったです。それでも毎日きちんと休めました。",
+	}
+	dist := distributionFromTexts(polite)
+
+	matchText := "今朝は少し肌寒い天気でした。温かいお茶を飲みながら新聞を読みました。穏やかな時間が流れていきました。\n\n" +
+		"昼からは近所を歩きました。商店街はいつもより賑わっていました。季節の移ろいを感じられて嬉しかったです。"
+	driftText := "本日は降雨である。会議資料を作成した。結論を整理し、対応を決定した。\n\n" +
+		"システムを再起動した。ログを確認した。異常はなかった。処理を継続する。"
+
+	matchExpl := Explain(dist, feature.ExtractText(matchText), feature.ExtractSegments(matchText), flags)
+	driftExpl := Explain(dist, feature.ExtractText(driftText), feature.ExtractSegments(driftText), flags)
+
+	if driftExpl.SegmentStyleDrift <= matchExpl.SegmentStyleDrift {
+		t.Fatalf("a register/voice-shifted draft should have a larger median paragraph drift: match=%.3f drift=%.3f",
+			matchExpl.SegmentStyleDrift, driftExpl.SegmentStyleDrift)
+	}
+
+	// The aggregate is informational: the similarity must equal the score computed
+	// without segments at all, so it provably never feeds scoring.
+	noSegments := Explain(dist, feature.ExtractText(driftText), nil, flags)
+	if driftExpl.Similarity != noSegments.Similarity {
+		t.Fatalf("segment_style_drift must not change similarity: with=%d without=%d",
+			driftExpl.Similarity, noSegments.Similarity)
+	}
+	if noSegments.SegmentStyleDrift != 0 {
+		t.Fatalf("with no segments the aggregate should be 0, got %.3f", noSegments.SegmentStyleDrift)
+	}
+}
+
 func distributionFromTexts(texts []string) feature.Distribution {
 	perDoc := make([]feature.Metrics, 0, len(texts))
 	for _, text := range texts {


### PR DESCRIPTION
## Why

This is the follow-up to #14 (topic masking), which is already merged. That PR explicitly deferred an optional "v2" item: a paragraph-level aggregate based on the median localizable drift, kept out of v1 so the explain/check JSON schema stayed unchanged. This PR adds it as a backward-compatible, additive field.

## What changed

`check --explain` and `check --format json` now report **`segment_style_drift`**: the median, across a document's prose paragraphs, of each paragraph's localizable drift (the mean z of its register, script-balance, and sentence-shape features against the author).

It is a robust, document-level companion to the existing worst-paragraph list — "how far does a *typical* paragraph stray", rather than only naming the single worst one. The two views agree on which paragraphs count: `segment_style_drift` reuses the same localizable feature subset and the same minimum-paragraph-length filter as the worst-paragraph localization.

- **Text output**: a `Typical paragraph drift (median): N.Nσ` line (shown only when there is enough prose to judge).
- **JSON output**: an additive `segment_style_drift` number. Existing fields are untouched, so current consumers are unaffected.
- **Informational only**: it never feeds the similarity score. A test asserts the score is identical whether or not segments are supplied, so it provably stays out of scoring.

## Tests

- `internal/profile/profile_test.go` — a register/voice-shifted draft yields a larger median paragraph drift than a matching draft, and the headline similarity is unchanged with vs. without segments (proving it does not affect scoring); empty input returns 0.
- `cmd/app_test.go` — the existing `check --format json` test now also asserts `segment_style_drift` is present and positive for the register-flipped draft.

`go test ./...` passes; `go vet ./...` is clean.

## Notes

- No scoring change, no breaking schema change, no new CLI command.
- README and CHANGELOG updated.