### PR TITLE
fix(cli): reject URL arguments in check and diff by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@ and per-release binaries and notes are published from git tags by GoReleaser.
   describe a profile differently, so profiles trained by an older omokage warn
   until retrained.
 
+### Fixed
+
+- `check` and `diff` now reject a URL argument by name, the same way `train` and
+  `doctor` already do, instead of joining it onto the working directory and
+  failing with a confusing `open .../https:/…: no such file`. All four commands
+  share one message ("URL inputs are not supported: … omokage reads local files
+  only …") so a URL passed anywhere a local path is expected fails identically.
+
 ## [0.5.0] - 2026-06-12
 
 ### Added

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -518,6 +518,13 @@ func (a *App) runCheck(args []string) int {
 	a.warnFeatureVersion(record)
 	a.warnSelfSimilarityCalibration(record)
 
+	// A URL where a local FILE is expected is rejected by name, exactly as train
+	// and doctor do, instead of being joined onto the working directory and
+	// surfacing as a confusing "no such file" after the "://" is mangled.
+	if looksLikeURL(flagSet.Arg(0)) {
+		writeLine(a.stderr, urlInputError(flagSet.Arg(0)))
+		return 1
+	}
 	targetPath, err := resolvePath(a.workDir, flagSet.Arg(0))
 	if err != nil {
 		writeLine(a.stderr, err)
@@ -643,6 +650,15 @@ func (a *App) runDiff(args []string) int {
 	features, ok := a.featuresOrDefault(scopeF)
 	if !ok {
 		return 1
+	}
+
+	// Reject a URL for either operand by name, as train and doctor do, rather
+	// than letting it fall through to a mangled-path "no such file".
+	for _, arg := range []string{flagSet.Arg(0), flagSet.Arg(1)} {
+		if looksLikeURL(arg) {
+			writeLine(a.stderr, urlInputError(arg))
+			return 1
+		}
 	}
 
 	leftPath, err := resolvePath(a.workDir, flagSet.Arg(0))
@@ -1272,7 +1288,7 @@ func gatherTrainingInputs(workDir string, inputs []string) (sources, files []str
 	seenInput := make(map[string]bool, len(inputs))
 	for _, raw := range inputs {
 		if looksLikeURL(raw) {
-			return nil, nil, fmt.Errorf("URL inputs are not supported: %s (omokage trains from local files only; save the page as a .md or .txt file and pass that path instead)", raw)
+			return nil, nil, urlInputError(raw)
 		}
 		abs, resolveErr := resolvePath(workDir, raw)
 		if resolveErr != nil {
@@ -1342,9 +1358,18 @@ func realPath(path string) string {
 	return path
 }
 
-// looksLikeURL reports whether an input is a URL rather than a local path, so
-// train can reject it with a clear, dedicated message instead of letting it fall
-// through to a confusing "input not found". It matches an RFC 3986 scheme
+// urlInputError is the shared, by-name rejection for a URL passed where a local
+// path is expected. Every command that reads files (train, doctor, check, diff)
+// returns it so the guidance is identical: omokage never fetches the network, so
+// a URL is a user mistake caught with a clear message instead of a confusing
+// "no such file" after the "://" is mangled into a path.
+func urlInputError(raw string) error {
+	return fmt.Errorf("URL inputs are not supported: %s (omokage reads local files only; save the page as a .md or .txt file and pass that path instead)", raw)
+}
+
+// looksLikeURL reports whether an input is a URL rather than a local path, so a
+// command can reject it with a clear, dedicated message instead of letting it
+// fall through to a confusing "input not found". It matches an RFC 3986 scheme
 // followed by "://" (http://, https://, ftp://, file://, s3://, …), which also
 // covers credential-bearing forms like https://user:pass@host/page that omokage
 // would never fetch.

--- a/cmd/app_error_test.go
+++ b/cmd/app_error_test.go
@@ -165,6 +165,59 @@ func TestRunDiffValidation(t *testing.T) {
 	}
 }
 
+// TestRunCheckRejectsURL pins that check refuses a URL target by name, the same
+// contract train and doctor already honor, instead of joining it onto the work
+// directory and failing with a mangled "no such file" path.
+func TestRunCheckRejectsURL(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+	writeTestFile(t, filepath.Join(workDir, "posts", "one.md"), "# Title\n\nI write short notes. However, I still use markdown.\n")
+	writeTestFile(t, filepath.Join(workDir, "posts", "two.txt"), "そして今日は静かです。だから文章は短めです。")
+	if code, _, stderr := runApp(t, workDir, "init"); code != 0 {
+		t.Fatalf("init failed: %s", stderr)
+	}
+	if code, _, stderr := runApp(t, workDir, "train", "--author", "me", "posts"); code != 0 {
+		t.Fatalf("train failed: %s", stderr)
+	}
+
+	code, stdout, stderr := runApp(t, workDir, "check", "--author", "me", "https://example.com/post.md")
+	if code != 1 {
+		t.Fatalf("expected exit 1 for a URL target, got %d (stderr=%q)", code, stderr)
+	}
+	if !strings.Contains(stderr, "URL inputs are not supported") {
+		t.Fatalf("expected a URL-not-supported error, got %q", stderr)
+	}
+	if strings.TrimSpace(stdout) != "" {
+		t.Fatalf("expected clean stdout on error, got %q", stdout)
+	}
+}
+
+// TestRunDiffRejectsURL pins the same by-name URL rejection for either diff
+// operand. diff needs no project, and the guard fires before the files are read.
+func TestRunDiffRejectsURL(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+	writeTestFile(t, filepath.Join(workDir, "a.md"), "# A\n\nそして文章です。だから続きます。\n")
+
+	for _, args := range [][]string{
+		{"diff", "https://example.com/a.md", "a.md"},
+		{"diff", "a.md", "ftp://example.com/b.txt"},
+	} {
+		code, stdout, stderr := runApp(t, workDir, args...)
+		if code != 1 {
+			t.Fatalf("%v: expected exit 1, got %d (stderr=%q)", args, code, stderr)
+		}
+		if !strings.Contains(stderr, "URL inputs are not supported") {
+			t.Fatalf("%v: expected a URL-not-supported error, got %q", args, stderr)
+		}
+		if strings.TrimSpace(stdout) != "" {
+			t.Fatalf("%v: expected clean stdout on error, got %q", args, stdout)
+		}
+	}
+}
+
 func TestRunListRejectsExtraArgs(t *testing.T) {
 	t.Parallel()
 

--- a/e2e/atago/errors.atago.yaml
+++ b/e2e/atago/errors.atago.yaml
@@ -129,6 +129,52 @@ scenarios:
               - "URL inputs are not supported"
               - "local files only"
 
+  - name: "input: check rejects a URL target by name, like train"
+    steps:
+      - run:
+          command: omokage init
+      - assert:
+          exit_code: 0
+      - run:
+          shell: true
+          command: omokage train --author me "$OMOKAGE_EXAMPLES/en/posts"
+      - assert:
+          exit_code: 0
+      # check reads a single local FILE; a URL is the same user mistake train
+      # guards, so it must fail by name rather than as a mangled "no such file".
+      - run:
+          command: omokage check --author me https://example.com/draft.md
+      - assert:
+          exit_code: 1
+          stdout:
+            empty: true
+          stderr:
+            contains:
+              - "URL inputs are not supported"
+              - "local files only"
+
+  - name: "input: diff rejects a URL for either operand"
+    steps:
+      # diff needs no store, and either operand being a URL is rejected up front.
+      - run:
+          shell: true
+          command: omokage diff https://example.com/a.md "$OMOKAGE_EXAMPLES/en/draft-keeps-voice.md"
+      - assert:
+          exit_code: 1
+          stdout:
+            empty: true
+          stderr:
+            contains: "URL inputs are not supported"
+      - run:
+          shell: true
+          command: omokage diff "$OMOKAGE_EXAMPLES/en/draft-keeps-voice.md" ftp://example.com/b.md
+      - assert:
+          exit_code: 1
+          stdout:
+            empty: true
+          stderr:
+            contains: "URL inputs are not supported"
+
   - name: "input: an unsupported extension is refused with the allowed set"
     steps:
       - fixture:


### PR DESCRIPTION
## Summary

`train` and `doctor` already reject a URL argument by name ("URL inputs are not supported: … omokage reads local files only …"), but `check` and `diff` did not: a URL fell through to `resolvePath`, which joined it onto the working directory, collapsed the `://` to `:/`, and surfaced a confusing `open /work/https:/example.com/draft.md: no such file or directory`. This makes all four file-reading commands reject a URL the same way, so a URL passed anywhere a local path is expected fails identically with an actionable message.

## Changes

- `cmd/app.go` — extract the URL rejection into a shared `urlInputError(raw)` helper (used by `train`/`doctor` via `gatherTrainingInputs`), and add a `looksLikeURL` guard to `runCheck` (the FILE argument) and `runDiff` (either operand) that returns it before the path is resolved. The message wording is unified to "omokage reads local files only" so it fits every command, not just `train`.
- `cmd/app_error_test.go` — `TestRunCheckRejectsURL` and `TestRunDiffRejectsURL` pin exit 1, the by-name error on stderr, and clean stdout for a URL target (check) and for either operand (diff).
- `e2e/atago/errors.atago.yaml` — two atago scenarios covering the same contract through the real binary.
- `CHANGELOG.md` — a Fixed entry under [Unreleased].

## Design Decisions

The guard is placed where each command is about to resolve the path — in `check` after the store, author, and profile are resolved, and in `diff` after the feature set is resolved — so the ordering of errors is unchanged relative to today (a missing project or profile still surfaces first) and only the previously-mangled URL case is corrected. The check is `looksLikeURL` (an RFC 3986 scheme followed by `://`), the same detector `train` uses, so Windows paths like `C:\Users\me\a.md` and drive-relative `a:b.md` are not mistaken for URLs. This is a message/exit-code sharpening of the existing surface, not a new subcommand or flag.

## Limitations

The reword changes the parenthetical in `train`/`doctor` from "trains from local files only" to "reads local files only"; the stable "URL inputs are not supported" prefix that the existing shellspec and unit tests assert is unchanged, and all of them still pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `check`, `diff`, and training commands now clearly reject URL inputs when local files are expected.
  * Error messages are now consistent and easier to understand, avoiding confusing file-path errors when a URL is provided.
  * `diff` now validates both inputs and fails cleanly if either one is a URL.
  * Added test coverage and end-to-end checks to verify these error cases behave as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->