### PR TITLE
docs: cut the 0.6.0 release and switch the coverage badge to octocov

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and per-release binaries and notes are published from git tags by GoReleaser.
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-07-07
+
 ### Added
 
 - `check --explain` / `check --format json` now report `segment_style_drift`, the

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 [![Build](https://github.com/nao1215/omokage/actions/workflows/build.yml/badge.svg)](https://github.com/nao1215/omokage/actions/workflows/build.yml)
 [![MultiPlatformUnitTest](https://github.com/nao1215/omokage/actions/workflows/unit_test.yml/badge.svg)](https://github.com/nao1215/omokage/actions/workflows/unit_test.yml)
 [![reviewdog](https://github.com/nao1215/omokage/actions/workflows/reviewdog.yml/badge.svg)](https://github.com/nao1215/omokage/actions/workflows/reviewdog.yml)
-[![Coverage](https://github.com/nao1215/omokage/actions/workflows/coverage.yml/badge.svg)](https://github.com/nao1215/omokage/actions/workflows/coverage.yml)
+![Coverage](https://raw.githubusercontent.com/nao1215/octocovs-central-repo/main/badges/nao1215/omokage/coverage.svg)
 [![Go Reference](https://pkg.go.dev/badge/github.com/nao1215/omokage.svg)](https://pkg.go.dev/github.com/nao1215/omokage)
-[![Go Report Card](https://goreportcard.com/badge/github.com/nao1215/omokage)](https://goreportcard.com/report/github.com/nao1215/omokage)
 ![GitHub](https://img.shields.io/github/license/nao1215/omokage)
 
 <p align="center">


### PR DESCRIPTION
## Summary

This is the release PR for v0.6.0. It cuts the accumulated `[Unreleased]` changelog into a dated `[0.6.0]` section (GoReleaser publishes the binaries and notes from the tag once this merges and the tag is pushed) and refreshes the README badges: the coverage badge now shows the real combined unit + E2E percentage from octocov, and the Go Report Card badge is dropped.

## Changes

- `CHANGELOG.md` — insert `## [0.6.0] - 2026-07-07` under `[Unreleased]`, following the same cut pattern as prior releases; the Added (segment_style_drift), Changed (topic-token masking, per-family lexical aggregation, structural weight, `feature.Version` 3), and Fixed (URL rejection in check/diff) entries move under it.
- `README.md` — replace the coverage-workflow status badge with the octocov coverage badge (`raw.githubusercontent.com/nao1215/octocovs-central-repo/main/badges/nao1215/omokage/coverage.svg`), matching sqly and gup, and remove the Go Report Card badge.

## Design Decisions

The octocov badge is served from the octocovs-central-repo, which aggregates each repo's coverage artifact into a committed SVG; omokage has been registered there (`ci(octocov): collect coverage report from nao1215/omokage`) so the badge renders the combined unit + atago-E2E number rather than a pass/fail workflow state. It replaces the existing `coverage.yml` status badge rather than sitting beside it, so there is a single, more informative "Coverage" badge instead of two with the same label. No version string is hardcoded in the tree — `omokage version` resolves from the tag via GoReleaser ldflags and the embedded module version — so cutting the changelog and tagging is the whole release.