### PR TITLE
chore(ci): bump atago to v0.17.0

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@v0.1.1
         with:
-          version: v0.16.0
+          version: v0.17.0
 
       # Combines unit-test coverage with self-hosted E2E coverage (the atago
       # suite runs a `go build -cover` omokage and collects covdata via

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@v0.1.1
         with:
-          version: v0.16.0
+          version: v0.17.0
 
       # The hermetic runner builds omokage and runs the atago suite in a
       # temp-backed HOME/profile-store sandbox, so local and CI execution are


### PR DESCRIPTION
Pins the E2E suites to [atago v0.17.0](https://github.com/nao1215/atago/releases/tag/v0.17.0).

That release adds a Scoop bucket for Windows installs and carries two failure-message fixes: an assertion whose observed value was empty now renders `(empty)` instead of omitting the `Actual:` section, and a run step whose output capture was cut short now names the exit code the process reached instead of reporting `failed to execute`.

No spec changes are needed — neither fix alters an assertion's verdict, only how a failure reads.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Atago version used by automated coverage and end-to-end testing workflows.
  * No user-facing functionality or workflow behavior was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->