### PR TITLE
chore(ci): bump atago to v0.20.0

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@v0.1.1
         with:
-          version: v0.17.0
+          version: v0.20.0
 
       # Combines unit-test coverage with self-hosted E2E coverage (the atago
       # suite runs a `go build -cover` omokage and collects covdata via

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@v0.1.1
         with:
-          version: v0.17.0
+          version: v0.20.0
 
       # The hermetic runner builds omokage and runs the atago suite in a
       # temp-backed HOME/profile-store sandbox, so local and CI execution are

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![MultiPlatformUnitTest](https://github.com/nao1215/omokage/actions/workflows/unit_test.yml/badge.svg)](https://github.com/nao1215/omokage/actions/workflows/unit_test.yml)
 [![reviewdog](https://github.com/nao1215/omokage/actions/workflows/reviewdog.yml/badge.svg)](https://github.com/nao1215/omokage/actions/workflows/reviewdog.yml)
 ![Coverage](https://raw.githubusercontent.com/nao1215/octocovs-central-repo/main/badges/nao1215/omokage/coverage.svg)
+[![tested with atago](https://img.shields.io/badge/tested%20with-atago-7c3aed?logo=data:image/svg%2Bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI%2BPHBhdGggZmlsbD0iI2ZmZiIgZD0iTTMuNiA0LjIgMTEuOSAxMmwtOC4zIDcuOC0xLjktMi4yTDcuOSAxMiAxLjcgNi40eiIvPjxyZWN0IGZpbGw9IiNmZmYiIHg9IjEyLjYiIHk9IjE3LjIiIHdpZHRoPSI5LjciIGhlaWdodD0iMi44IiByeD0iMS40Ii8%2BPC9zdmc%2B&logoColor=white)](https://github.com/nao1215/atago)
 [![Go Reference](https://pkg.go.dev/badge/github.com/nao1215/omokage.svg)](https://pkg.go.dev/github.com/nao1215/omokage)
 ![GitHub](https://img.shields.io/github/license/nao1215/omokage)
 [![GitHub Downloads (all assets, all releases)](https://img.shields.io/github/downloads/nao1215/omokage/total)](https://github.com/nao1215/omokage/releases)


### PR DESCRIPTION
Move the pinned atago used by the E2E and coverage workflows from v0.17.0 to v0.20.0.

Three releases. Two entries could matter to a suite:

- v0.18.0: a flaky scenario — one that failed and then passed on a re-run, or that failed some `--repeat` iterations — now fails the run instead of exiting 0. The runner here passes neither flag, so nothing changes.
- v0.19.0: a flag written after the spec paths is read as a flag rather than as a spec path, and `--fail-fast` stops for every outcome that fails the run.

All 38 atago scenarios pass locally on v0.20.0 with no spec changes.

Also adds a tested-with-atago badge next to the coverage badge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an Atago testing badge to the project README, providing quick access to testing information.

* **Chores**
  * Updated the automated coverage and end-to-end testing setup to use a newer Atago release, improving consistency with the current testing environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
