### PR TITLE
docs(readme): document the omokage-bin AUR package

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ It is built for an LLM as much as for a person: an agent can run `check` after e
 go install github.com/nao1215/omokage@latest
 ```
 
+On Arch Linux, [`omokage-bin`](https://aur.archlinux.org/packages/omokage-bin) is community-maintained and installs the release binary:
+
+```shell
+yay -S omokage-bin   # or: paru -S omokage-bin
+```
+
 Runs on Windows, macOS, and Linux. Building from source needs Go 1.25 or later.
 
 ## Quick start


### PR DESCRIPTION
[`omokage-bin`](https://aur.archlinux.org/packages/omokage-bin) (currently 0.6.0, matching the latest tag) installs this repository's release binary on Arch Linux, but the Install section offered only `go install`.

README only; no other install route changed. The Pages site holds the benchmark charts, not install docs, so there is nothing to mirror there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Arch Linux installation instructions using the community-maintained `omokage-bin` AUR package.
  * Included example commands for installing with `yay` or `paru`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->