### PR TITLE
docs(readme): credit the external maintainer who packages omokage

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,35 @@
+{
+  "projectName": "omokage",
+  "projectOwner": "nao1215",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 75,
+  "commit": false,
+  "commitConvention": "angular",
+  "contributorsPerLine": 7,
+  "linkToUsage": false,
+  "contributors": [
+    {
+      "login": "nao1215",
+      "name": "CHIKAMATSU Naohiro",
+      "avatar_url": "https://avatars.githubusercontent.com/u/22737008?v=4",
+      "profile": "https://debimate.jp/",
+      "contributions": [
+        "code",
+        "doc"
+      ]
+    },
+    {
+      "login": "Dominiquini",
+      "name": "Rafael Baboni Dominiquini",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1180808?v=4",
+      "profile": "https://rafaeldominiquini.ddns.net/",
+      "contributions": [
+        "platform"
+      ]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -179,6 +179,29 @@ omokage looks at style, not meaning: it cannot tell whether a draft is correct, 
 
 omokage (面影) is written with 面 (face) and 影 (shadow, trace): the remembered image of someone, the likeness that comes back to mind. The name is borrowed from [Omokage](https://www.toraya-group.co.jp/products/collections/yokan-omokage), a yokan by Toraya that I like.
 
+## Contributors ✨
+
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://debimate.jp/"><img src="https://avatars.githubusercontent.com/u/22737008?v=4?s=75" width="75px;" alt="CHIKAMATSU Naohiro"/><br /><sub><b>CHIKAMATSU Naohiro</b></sub></a><br /><a href="https://github.com/nao1215/omokage/commits?author=nao1215" title="Code">💻</a> <a href="https://github.com/nao1215/omokage/commits?author=nao1215" title="Documentation">📖</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://rafaeldominiquini.ddns.net/"><img src="https://avatars.githubusercontent.com/u/1180808?v=4?s=75" width="75px;" alt="Rafael Baboni Dominiquini"/><br /><sub><b>Rafael Baboni Dominiquini</b></sub></a><br /><a href="#platform-Dominiquini" title="Packaging/porting to new platform">📦</a></td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
+
 ## License
 
 MIT. See [LICENSE](./LICENSE).


### PR DESCRIPTION
## Summary

Rafael Baboni Dominiquini maintains the `omokage-bin` package in the AUR, which is how Arch users install omokage. The repository had no Contributors section at all, so there was nowhere to record that. This adds one and credits him with the `platform` (📦) type.

## Changes

- `.all-contributorsrc`: added, listing nao1215 and Rafael Baboni Dominiquini (`Dominiquini`).
- `README.md`: added a `## Contributors ✨` section above `## License`, generated by `all-contributors-cli`.

## Design Decisions

The section follows the same shape the other repositories here use, so a reader moving between them sees the same thing in the same place. The badge markers were left out: the other repositories put an all-contributors badge on line 1, and adding one here would change the top of the README for a reason unrelated to this change. The list works without it.

`linkToUsage` is `false`, so the tool's "Add your contributions" footer is not rendered. The existing "Contributions of any kind welcome!" line already says that in the project's own words.

`platform` is the all-contributors type defined as "Packaging/porting to support a new platform", which is what maintaining the AUR package is.

The GitHub account was confirmed rather than guessed: the commit address on the AUR package (`rafaeldominiquini@gmail.com`) resolves to exactly one GitHub account, and that account's display name matches the AUR commit author name. He maintains the same `-bin` package for five other repositories here, which are being credited separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Contributors section to the README.
  * Recognized contributors for code, documentation, and platform contributions.
  * Added contributor display configuration for consistent project acknowledgments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->